### PR TITLE
Repair CompatHelper workflow

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -7,6 +7,7 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,6 +13,8 @@ jobs:
         shell: julia {0}
         run: |
           using CompatHelper
+          print(pwd())
+          print(readdir(pwd()))
           subdirs = [""; readdir("lib/"; join=true)]
           CompatHelper.main(; subdirs)
         env:

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,8 +14,6 @@ jobs:
         shell: julia {0}
         run: |
           using CompatHelper
-          print(pwd())
-          print(readdir(pwd()))
           subdirs = [""; readdir("lib/"; join=true)]
           CompatHelper.main(; subdirs)
         env:


### PR DESCRIPTION
This PR actually repairs the CompatHelper workflow for subpackages by checkout out the repo before running CompatHelper.