### PR TITLE
Make InferenceData and Dataset type-unstable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,13 @@ version = "0.2.2"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
 Compat = "3.46.0, 4.2.0"
 DimensionalData = "0.20, 0.21, 0.22"
 OffsetArrays = "1"
+OrderedCollections = "1"
 julia = "1.6"
 
 [extras]

--- a/src/InferenceObjects.jl
+++ b/src/InferenceObjects.jl
@@ -3,6 +3,7 @@ module InferenceObjects
 using Compat: stack
 using Dates: Dates
 using DimensionalData: DimensionalData, Dimensions, LookupArrays
+using OrderedCollections: OrderedCollections
 
 # groups that are officially listed in the schema
 const SCHEMA_GROUPS = (

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,5 +1,5 @@
 """
-    Dataset{L} <: DimensionalData.AbstractDimStack{L}
+    Dataset <: DimensionalData.AbstractDimStack{NamedTuple}
 
 Container of dimensional arrays sharing some dimensions.
 
@@ -25,9 +25,8 @@ if an `xarray.Dataset` is passed to Julia, its data must be copied.
 In most cases, use [`convert_to_dataset`](@ref) to create a `Dataset` instead of directly
 using a constructor.
 """
-struct Dataset{L,D<:DimensionalData.AbstractDimStack{L}} <:
-       DimensionalData.AbstractDimStack{L}
-    data::D
+struct Dataset <: DimensionalData.AbstractDimStack{NamedTuple}
+    data::DimensionalData.DimStack
 end
 
 Dataset(args...; kwargs...) = Dataset(DimensionalData.DimStack(args...; kwargs...))

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -113,7 +113,7 @@ end
 
 # DimensionalData interop
 
-for f in [:data, :dims, :refdims, :metadata, :layerdims, :layermetadata]
+for f in [:data, :dims, :refdims, :metadata, :layerdims, :layermetadata, :layers]
     @eval begin
         DimensionalData.$(f)(ds::Dataset) = DimensionalData.$(f)(parent(ds))
     end

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -249,8 +249,6 @@ function Base.merge(data::InferenceData, others::InferenceData...)
 end
 
 function rekey(data::InferenceData, keymap)
-    groups_old = groups(data)
-    names_new = map(k -> get(keymap, k, k), propertynames(groups_old))
-    groups_new = NamedTuple{names_new}(Tuple(groups_old))
-    return InferenceData(groups_new)
+    pairs_new = (get(keymap, k, k) => v for (k, v) in pairs(groups(data)))
+    return InferenceData(; pairs_new...)
 end

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -30,6 +30,7 @@ struct InferenceData
         )
         return InferenceData(groups_new)
     end
+    InferenceData(groups::InferenceDataStorageType) = new(groups)
 end
 InferenceData(data::NamedTuple) = InferenceData(; data...)
 InferenceData(; kwargs...) = InferenceData(kwargs)

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -38,6 +38,8 @@ InferenceData(data::InferenceData) = data
 
 Base.parent(data::InferenceData) = getfield(data, :groups)
 
+Base.:(==)(data::InferenceData, other::InferenceData) = parent(data) == parent(other)
+
 # these 3 interfaces ensure InferenceData behaves like a NamedTuple
 
 # properties interface

--- a/test/convert_inference_data.jl
+++ b/test/convert_inference_data.jl
@@ -36,7 +36,7 @@ using InferenceObjects, DimensionalData, Test
         @testset "convert_to_inference_data(::AbstractDimStack)" begin
             ds = namedtuple_to_dataset((x=randn(10, 4), y=randn(5, 10, 4)))
             idata1 = convert_to_inference_data(ds; group=:prior)
-            @test InferenceObjects.groupnames(idata1) == (:prior,)
+            @test issetequal(InferenceObjects.groupnames(idata1), [:prior])
             idata2 = InferenceData(; prior=ds)
             @test idata2 == idata1
             idata3 = convert_to_inference_data(parent(ds); group=:prior)
@@ -50,13 +50,13 @@ using InferenceObjects, DimensionalData, Test
             end
             idata = convert_to_inference_data(data)
             check_idata_schema(idata)
-            @test InferenceObjects.groupnames(idata) == (:posterior,)
+            @test issetequal(InferenceObjects.groupnames(idata), [:posterior])
             posterior = idata.posterior
             @test posterior.A == data[:A]
             @test posterior.B == data[:B]
             idata2 = convert_to_inference_data(data; group=:prior)
             check_idata_schema(idata2)
-            @test InferenceObjects.groupnames(idata2) == (:prior,)
+            @test issetequal(InferenceObjects.groupnames(idata2), [:prior])
             @test idata2.prior == idata.posterior
         end
 
@@ -68,7 +68,7 @@ using InferenceObjects, DimensionalData, Test
             end
             idata = convert_to_inference_data(data)
             check_idata_schema(idata)
-            @test InferenceObjects.groupnames(idata) == (:posterior,)
+            @test issetequal(InferenceObjects.groupnames(idata), [:posterior])
             posterior = idata.posterior
             if T <: DimensionalData.DimArray
                 @test posterior.y == data
@@ -77,7 +77,7 @@ using InferenceObjects, DimensionalData, Test
             end
             idata2 = convert_to_inference_data(data; group=:prior)
             check_idata_schema(idata2)
-            @test InferenceObjects.groupnames(idata2) == (:prior,)
+            @test issetequal(InferenceObjects.groupnames(idata2), [:prior])
             @test idata2.prior == idata.posterior
         end
     end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -139,7 +139,8 @@ using InferenceObjects, DimensionalData, Test
         )
         ds = namedtuple_to_dataset(vars; library="MyLib", coords, dims, attrs)
         @test ds isa Dataset
-        for (var_name, var_data) in pairs(DimensionalData.layers(ds))
+        for var_name in keys(ds)
+            var_data = ds[var_name]
             @test var_data isa DimensionalData.DimArray
             @test var_name === DimensionalData.name(var_data)
             @test var_data == vars[var_name]

--- a/test/inference_data.jl
+++ b/test/inference_data.jl
@@ -11,13 +11,12 @@ using InferenceObjects, DimensionalData, Test
     posterior = random_dataset(var_names, dims, coords, metadata)
     prior = random_dataset(var_names, dims, coords, metadata)
     observed_data = random_dataset(data_names, dims, coords, metadata)
-    group_data = (; prior, observed_data, posterior)
-    group_data_ordered = (; posterior, prior, observed_data)
+    group_data = Dict(pairs((; prior, observed_data, posterior)))
 
     @testset "constructors" begin
         idata = @inferred(InferenceData(group_data))
         @test idata isa InferenceData
-        @test getfield(idata, :groups) === group_data_ordered
+        @test parent(idata) == group_data
 
         @test InferenceData(; group_data...) == idata
         @test InferenceData(idata) === idata
@@ -26,7 +25,7 @@ using InferenceObjects, DimensionalData, Test
     idata = InferenceData(group_data)
 
     @testset "properties" begin
-        @test propertynames(idata) === propertynames(group_data_ordered)
+        @test propertynames(idata) == collect(keys(group_data))
         @test getproperty(idata, :posterior) === posterior
         @test getproperty(idata, :prior) === prior
         @test hasproperty(idata, :posterior)
@@ -35,40 +34,38 @@ using InferenceObjects, DimensionalData, Test
     end
 
     @testset "iteration" begin
-        @test keys(idata) === keys(group_data_ordered)
+        @test keys(idata) == collect(keys(group_data))
         @test haskey(idata, :posterior)
         @test haskey(idata, :prior)
         @test !haskey(idata, :log_likelihood)
-        @test values(idata) === values(group_data_ordered)
-        @test pairs(idata) isa Base.Iterators.Pairs
-        @test pairs(idata) === pairs(group_data_ordered)
-        @test length(idata) == length(group_data_ordered)
-        @test iterate(idata) === iterate(group_data_ordered)
+        @test values(idata) == collect(values(group_data))
+        @test pairs(idata) isa AbstractDict{Symbol,Dataset}
+        @test pairs(idata) == pairs(group_data)
+        @test length(idata) == length(group_data)
+        @test iterate(idata) == iterate(parent(idata))
         for i in 1:(length(idata) + 1)
-            @test iterate(idata, i) === iterate(group_data_ordered, i)
+            @test iterate(idata, i) === iterate(parent(idata), i)
         end
-        @test eltype(idata) <: Dataset
-        @test collect(idata) isa Vector{<:Dataset}
+        @test eltype(idata) <: Pair{Symbol,Dataset}
+        @test collect(idata) isa Vector{Pair{Symbol,Dataset}}
     end
 
     @testset "indexing" begin
         @test idata[:posterior] === posterior
         @test idata[:prior] === prior
-        @test idata[1] === posterior
-        @test idata[2] === prior
 
         idata_sel = idata[dima=At(2:3), dimb=At(6)]
         @test idata_sel isa InferenceData
-        @test InferenceObjects.groupnames(idata_sel) === InferenceObjects.groupnames(idata)
+        @test InferenceObjects.groupnames(idata_sel) == InferenceObjects.groupnames(idata)
         @test Dimensions.index(idata_sel.posterior, :dima) == 2:3
         @test Dimensions.index(idata_sel.prior, :dima) == 2:3
         @test Dimensions.index(idata_sel.posterior, :dimb) == [6]
         @test Dimensions.index(idata_sel.prior, :dimb) == [6]
 
         if VERSION ≥ v"1.7"
-            idata_sel = idata[(:posterior, :observed_data), dimy=1, dimb=1, shared=At("s1")]
+            idata_sel = idata[[:posterior, :observed_data], dimy=1, dimb=1, shared=At("s1")]
             @test idata_sel isa InferenceData
-            @test InferenceObjects.groupnames(idata_sel) === (:posterior, :observed_data)
+            @test InferenceObjects.groupnames(idata_sel) == [:posterior, :observed_data]
             @test Dimensions.index(idata_sel.posterior, :dima) == coords.dima
             @test Dimensions.index(idata_sel.posterior, :dimb) == coords.dimb[[1]]
             @test Dimensions.index(idata_sel.posterior, :shared) == ["s1"]
@@ -80,9 +77,9 @@ using InferenceObjects, DimensionalData, Test
         @test ds_sel isa Dataset
         @test !hasdim(ds_sel, :chain)
 
-        idata2 = Base.setindex(idata, posterior, :warmup_posterior)
-        @test keys(idata2) === (keys(idata)..., :warmup_posterior)
-        @test idata2[:warmup_posterior] === posterior
+        idata.warmup_posterior = posterior
+        @test issetequal(keys(idata), [keys(group_data)..., :warmup_posterior])
+        @test idata[:warmup_posterior] == posterior
     end
 
     @testset "isempty" begin
@@ -91,8 +88,8 @@ using InferenceObjects, DimensionalData, Test
     end
 
     @testset "groups" begin
-        @test InferenceObjects.groups(idata) === group_data_ordered
-        @test InferenceObjects.groups(InferenceData(; prior)) === (; prior)
+        @test InferenceObjects.groups(idata) === getfield(idata, :groups)
+        @test InferenceObjects.groups(InferenceData(; prior)) == pairs((; prior))
     end
 
     @testset "hasgroup" begin
@@ -102,8 +99,10 @@ using InferenceObjects, DimensionalData, Test
     end
 
     @testset "groupnames" begin
-        @test InferenceObjects.groupnames(idata) === propertynames(group_data_ordered)
-        @test InferenceObjects.groupnames(InferenceData(; posterior)) === (:posterior,)
+        @test issetequal(
+            InferenceObjects.groupnames(idata), [keys(group_data)..., :warmup_posterior]
+        )
+        @test InferenceObjects.groupnames(InferenceData(; posterior)) == [:posterior]
     end
 
     @testset "show" begin
@@ -113,7 +112,8 @@ using InferenceObjects, DimensionalData, Test
             InferenceData with groups:
               > posterior
               > prior
-              > observed_data"""
+              > observed_data
+              > warmup_posterior"""
         end
 
         @testset "html" begin

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -56,8 +56,8 @@ end
 function test_idata_approx_equal(
     idata1::InferenceData, idata2::InferenceData; check_metadata=true
 )
-    @test InferenceObjects.groupnames(idata1) === InferenceObjects.groupnames(idata2)
-    for (ds1, ds2) in zip(idata1, idata2)
+    @test InferenceObjects.groupnames(idata1) == InferenceObjects.groupnames(idata2)
+    for (ds1, ds2) in zip(values(idata1), values(idata2))
         @test issetequal(keys(ds1), keys(ds2))
         for var_name in keys(ds1)
             da1 = ds1[var_name]


### PR DESCRIPTION
Fixes #15 by removing type annotations from `InferenceData` and `Dataset`. This makes high-order operations on these types compile quickly (and possibly automatically precompile), while operations on arrays are still compiled for the specific dimensions of that array and so are still fast.