### PR TITLE
Change default dimension order to (draw, chain, params...)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.2.5"
+version = "0.3.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,14 @@ version = "0.2.5"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Compat = "3.46.0, 4.2.0"
 DimensionalData = "0.20, 0.21, 0.22, 0.23"
 OffsetArrays = "1"
 OrderedCollections = "1"
+Tables = "1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.3.0-DEV"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/lib/InferenceObjectsNetCDF/Project.toml
+++ b/lib/InferenceObjectsNetCDF/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjectsNetCDF"
 uuid = "7cb6d088-77df-42c3-8f05-5ca8d42599d1"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
@@ -11,7 +11,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 DimensionalData = "0.20, 0.21, 0.22, 0.23"
-InferenceObjects = "0.2"
+InferenceObjects = "0.2, 0.3"
 NCDatasets = "0.12"
 Reexport = "1"
 julia = "1.6"

--- a/src/InferenceObjects.jl
+++ b/src/InferenceObjects.jl
@@ -3,6 +3,7 @@ module InferenceObjects
 using Compat: stack
 using Dates: Dates
 using DimensionalData: DimensionalData, Dimensions, LookupArrays
+using Tables: Tables
 
 # groups that are officially listed in the schema
 const SCHEMA_GROUPS = (
@@ -25,6 +26,8 @@ const SCHEMA_GROUPS = (
 )
 const SCHEMA_GROUPS_DICT = Dict(n => i for (i, n) in enumerate(SCHEMA_GROUPS))
 const DEFAULT_SAMPLE_DIMS = Dimensions.key2dim((:draw, :chain))
+const DEFAULT_DRAW_DIM = 1
+const DEFAULT_CHAIN_DIM = 2
 
 export Dataset, InferenceData
 export convert_to_dataset,

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -51,13 +51,13 @@ Generate `DimensionsionalData.Dimension` objects for each dimension of `array`.
     dimension. If indices for a dimension in `dims` are provided, they are used even if
     the dimension contains its own indices. If a dimension is missing, its indices are
     automatically generated.
-  - `default_dims`: A collection of dims to be appended to `dims` whose elements have the
+  - `default_dims`: A collection of dims to be prepended to `dims` whose elements have the
     same constraints.
 """
 function generate_dims(array, name; dims=(), coords=(;), default_dims=())
     num_default_dims = length(default_dims)
     if length(dims) + num_default_dims > ndims(array)
-        dim_names = Dimensions.name(Dimensions.basedims((dims..., default_dims...)))
+        dim_names = Dimensions.name(Dimensions.basedims((default_dims..., dims...)))
         throw(
             DimensionMismatch(
                 "Provided dimensions $dim_names more than dimensions of array: $(ndims(array))",
@@ -70,7 +70,7 @@ function generate_dims(array, name; dims=(), coords=(;), default_dims=())
         dim === nothing && return Symbol("$(name)_dim_$(i)")
         return dim
     end
-    dims_all = (dims_named..., default_dims...)
+    dims_all = (default_dims..., dims_named...)
     axes_all = axes(array)
     T = NTuple{ndims(array),Dimensions.Dimension}
     dims_with_coords = as_dimension.(dims_all, Ref(coords), axes_all)::T

--- a/src/from_namedtuple.jl
+++ b/src/from_namedtuple.jl
@@ -160,7 +160,7 @@ function from_namedtuple(
     return all_idata
 end
 function from_namedtuple(data::AbstractVector{<:AbstractVector{<:NamedTuple}}; kwargs...)
-    return from_namedtuple(namedtuple_of_arrays(data); kwargs...)
+    return from_namedtuple(stack_chains(map(stack_draws, data)); kwargs...)
 end
 
 """

--- a/src/from_namedtuple.jl
+++ b/src/from_namedtuple.jl
@@ -1,7 +1,5 @@
 """
     from_namedtuple(posterior::NamedTuple; kwargs...) -> InferenceData
-    from_namedtuple(posterior::Vector{<:NamedTuple}; kwargs...) -> InferenceData
-    from_namedtuple(posterior::Matrix{<:NamedTuple}; kwargs...) -> InferenceData
     from_namedtuple(posterior::Vector{Vector{<:NamedTuple}}; kwargs...) -> InferenceData
     from_namedtuple(
         posterior::NamedTuple,
@@ -22,11 +20,9 @@ whose first dimensions correspond to the dimensions of the containers.
   - `posterior`: The data to be converted. It may be of the following types:
 
       + `::NamedTuple`: The keys are the variable names and the values are arrays with
-        dimensions `([sizes...], ndraws, [nchains])`.
-      + `::Matrix{<:NamedTuple}`: Each element is a single draw from a single chain, with
-        array/scalar values with dimensions `sizes`. The dimensions of the matrix container
-        are `(ndraws, nchains)`
-      + `::Vector{Vector{<:NamedTuple}}`: The same as the above case.
+        dimensions `(ndraws, nchains[, sizes...])`.
+      + `::Vector{Vector{<:NamedTuple}}`: A vector of length `nchains` whose elements have
+        length `ndraws`.
 
 # Keywords
 
@@ -62,18 +58,12 @@ nchains = 2
 ndraws = 100
 
 data1 = (
-    x=rand(ndraws, nchains), y=randn(2, ndraws, nchains), z=randn(3, 2, ndraws, nchains)
+    x=rand(ndraws, nchains), y=randn(ndraws, nchains, 2), z=randn(ndraws, nchains, 3, 2)
 )
 idata1 = from_namedtuple(data1)
 
-data2 = [(x=rand(ndraws), y=randn(2, ndraws), z=randn(3, 2, ndraws)) for _ in 1:nchains];
+data2 = [[(x=rand(), y=randn(2), z=randn(3, 2)) for _ in 1:ndraws] for _ in 1:nchains];
 idata2 = from_namedtuple(data2)
-
-data3 = [(x=rand(), y=randn(2), z=randn(3, 2)) for _ in 1:ndraws, _ in 1:nchains];
-idata3 = from_namedtuple(data3)
-
-data4 = [[(x=rand(), y=randn(2), z=randn(3, 2)) for _ in 1:ndraws] for _ in 1:nchains];
-idata4 = from_namedtuple(data4)
 ```
 """
 from_namedtuple
@@ -169,20 +159,12 @@ function from_namedtuple(
 
     return all_idata
 end
-function from_namedtuple(data::AbstractVector{<:NamedTuple}; kwargs...)
-    return from_namedtuple(namedtuple_of_arrays(data); kwargs...)
-end
-function from_namedtuple(data::AbstractMatrix{<:NamedTuple}; kwargs...)
-    return from_namedtuple(namedtuple_of_arrays(data); kwargs...)
-end
 function from_namedtuple(data::AbstractVector{<:AbstractVector{<:NamedTuple}}; kwargs...)
     return from_namedtuple(namedtuple_of_arrays(data); kwargs...)
 end
 
 """
     convert_to_inference_data(obj::NamedTuple; kwargs...) -> InferenceData
-    convert_to_inference_data(obj::Vector{<:NamedTuple}; kwargs...) -> InferenceData
-    convert_to_inference_data(obj::Matrix{<:NamedTuple}; kwargs...) -> InferenceData
     convert_to_inference_data(obj::Vector{Vector{<:NamedTuple}}; kwargs...) -> InferenceData
 
 Convert `obj` to an [`InferenceData`](@ref). See [`from_namedtuple`](@ref) for a description

--- a/src/from_namedtuple.jl
+++ b/src/from_namedtuple.jl
@@ -172,14 +172,7 @@ of `obj` possibilities and `kwargs`.
 """
 function convert_to_inference_data(
     data::T; group=:posterior, kwargs...
-) where {
-    T<:Union{
-        NamedTuple,
-        AbstractVector{<:NamedTuple},
-        AbstractMatrix{<:NamedTuple},
-        AbstractVector{<:AbstractVector{<:NamedTuple}},
-    },
-}
+) where {T<:Union{NamedTuple,AbstractVector{<:AbstractVector{<:NamedTuple}}}}
     group = Symbol(group)
     group === :posterior && return from_namedtuple(data; kwargs...)
     return from_namedtuple(; group => data, kwargs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,6 +8,30 @@ recursive_stack(x) = x
 recursive_stack(x::AbstractArray{<:AbstractArray}) = recursive_stack(stack(x))
 
 """
+    stack_draws(draws_table) -> NamedTuple
+
+Combine draws from a single chain into a single array by stacking on a new first dimension.
+
+`draws_table` must implement the Tables.jl interface. The stacking is performed separately
+for each column, and the resulting `NamedTuple` has the same fields as the columns.
+"""
+stack_draws
+stack_draws(draws) = _stack_cols(draws; dims=DEFAULT_DRAW_DIM)
+
+"""
+    stack_chains(chains_table) -> NamedTuple
+
+Combine `chains` into a single array by stacking on a new second dimension.
+
+`chains_table` must implement the Tables.jl interface. The stacking is performed separately
+for each column, and the resulting `NamedTuple` has the same fields as the columns.
+"""
+stack_chains
+stack_chains(chains) = _stack_cols(chains; dims=DEFAULT_CHAIN_DIM)
+
+_stack_cols(table; dims) = map(col -> stack(col; dims), Tables.columntable(table))
+
+"""
     namedtuple_of_arrays(x::NamedTuple) -> NamedTuple
     namedtuple_of_arrays(x::AbstractArray{NamedTuple}) -> NamedTuple
     namedtuple_of_arrays(x::AbstractArray{AbstractArray{<:NamedTuple}}) -> NamedTuple

--- a/test/convert_dataset.jl
+++ b/test/convert_dataset.jl
@@ -7,7 +7,7 @@ using InferenceObjects, DimensionalData, Test
         L = 3
         nchains = 4
         ndraws = 500
-        vars = (a=randn(J, ndraws, nchains), b=randn(K, L, ndraws, nchains))
+        vars = (a=randn(ndraws, nchains, J), b=randn(ndraws, nchains, K, L))
         coords = (bi=2:(K + 1), draw=1:2:1_000)
         dims = (b=[:bi, nothing],)
         attrs = Dict("mykey" => 5)
@@ -23,10 +23,10 @@ using InferenceObjects, DimensionalData, Test
         nchains = 4
         ndraws = 100
         nshared = 3
-        xdims = (:shared, :draw, :chain)
-        x = DimArray(randn(nshared, ndraws, nchains), xdims)
-        ydims = (Dim{:ydim1}(Any["a", "b"]), Dim{:shared}, :draw, :chain)
-        y = DimArray(randn(2, nshared, ndraws, nchains), ydims)
+        xdims = (:draw, :chain, :shared)
+        x = DimArray(randn(ndraws, nchains, nshared), xdims)
+        ydims = (:draw, :chain, Dim{:ydim1}(Any["a", "b"]), Dim{:shared})
+        y = DimArray(randn(ndraws, nchains, 2, nshared), ydims)
         metadata = Dict("prop1" => "val1", "prop2" => "val2")
         ds = Dataset((; x, y); metadata)
 
@@ -36,7 +36,7 @@ using InferenceObjects, DimensionalData, Test
         end
 
         @testset "convert_to_dataset(::$T; kwargs...)" for T in (Dict, NamedTuple)
-            data = (x=randn(100, 4), y=randn(2, 100, 4))
+            data = (x=randn(100, 4), y=randn(100, 4, 2))
             if T <: Dict
                 data = T(pairs(data))
             end
@@ -46,7 +46,7 @@ using InferenceObjects, DimensionalData, Test
             @test DimensionalData.name(DimensionalData.dims(ds2.x)) == (:draw, :chain)
             @test ds2.y == data[:y]
             @test DimensionalData.name(DimensionalData.dims(ds2.y)) ==
-                (:y_dim_1, :draw, :chain)
+                (:draw, :chain, :y_dim_1)
         end
 
         @testset "convert_to_dataset(::InferenceData; kwargs...)" begin

--- a/test/convert_inference_data.jl
+++ b/test/convert_inference_data.jl
@@ -34,7 +34,7 @@ using InferenceObjects, DimensionalData, Test
 
     @testset "convert_to_inference_data" begin
         @testset "convert_to_inference_data(::AbstractDimStack)" begin
-            ds = namedtuple_to_dataset((x=randn(10, 4), y=randn(5, 10, 4)))
+            ds = namedtuple_to_dataset((x=randn(10, 4), y=randn(10, 4, 5)))
             idata1 = convert_to_inference_data(ds; group=:prior)
             @test InferenceObjects.groupnames(idata1) == (:prior,)
             idata2 = InferenceData(; prior=ds)
@@ -44,7 +44,7 @@ using InferenceObjects, DimensionalData, Test
         end
 
         @testset "convert_to_inference_data(::$T)" for T in (NamedTuple, Dict)
-            data = (A=randn(2, 10, 2), B=randn(5, 2, 10, 2))
+            data = (A=randn(10, 2, 2), B=randn(10, 2, 5, 2))
             if T <: Dict
                 data = Dict(pairs(data))
             end
@@ -62,7 +62,7 @@ using InferenceObjects, DimensionalData, Test
 
         @testset "convert_to_inference_data(::$T)" for T in
                                                        (Array, DimensionalData.DimArray)
-            data = randn(2, 10, 2)
+            data = randn(10, 2, 2)
             if T <: DimensionalData.DimArray
                 data = DimensionalData.DimArray(data, (:a, :b, :c); name=:y)
             end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -6,10 +6,10 @@ using InferenceObjects, DimensionalData, Test
             nchains = 4
             ndraws = 100
             nshared = 3
-            xdims = (:shared, :draw, :chain)
-            x = DimArray(randn(nshared, ndraws, nchains), xdims)
-            ydims = (:ydim1, :shared, :draw, :chain)
-            y = DimArray(randn(2, nshared, ndraws, nchains), ydims)
+            xdims = (:draw, :chain, :shared)
+            x = DimArray(randn(ndraws, nchains, nshared), xdims)
+            ydims = (:draw, :chain, :ydim1, :shared)
+            y = DimArray(randn(ndraws, nchains, 2, nshared), ydims)
             metadata = Dict("prop1" => "val1", "prop2" => "val2")
 
             @testset "from NamedTuple" begin
@@ -69,10 +69,10 @@ using InferenceObjects, DimensionalData, Test
         nchains = 4
         ndraws = 100
         nshared = 3
-        xdims = (:shared, :draw, :chain)
-        x = DimArray(randn(nshared, ndraws, nchains), xdims)
-        ydims = (:ydim1, :shared, :draw, :chain)
-        y = DimArray(randn(2, nshared, ndraws, nchains), ydims)
+        xdims = (:draw, :chain, :shared)
+        x = DimArray(randn(ndraws, nchains, nshared), xdims)
+        ydims = (:draw, :chain, :ydim1, :shared)
+        y = DimArray(randn(ndraws, nchains, 2, nshared), ydims)
         metadata = Dict("prop1" => "val1", "prop2" => "val2")
         ds = Dataset((; x, y); metadata)
 
@@ -117,20 +117,20 @@ using InferenceObjects, DimensionalData, Test
         L = 3
         nchains = 4
         ndraws = 500
-        vars = (a=randn(J, ndraws, nchains), b=randn(K, L, ndraws, nchains))
+        vars = (a=randn(ndraws, nchains, J), b=randn(ndraws, nchains, K, L))
         coords = (bi=2:(K + 1), draw=1:2:1_000)
         dims = (b=[:bi, nothing],)
         expected_dims = (
             a=(
-                Dimensions.Dim{:a_dim_1}(1:J),
                 Dimensions.Dim{:draw}(1:2:1_000),
                 Dimensions.Dim{:chain}(1:nchains),
+                Dimensions.Dim{:a_dim_1}(1:J),
             ),
             b=(
-                Dimensions.Dim{:bi}(2:(K + 1)),
-                Dimensions.Dim{:b_dim_2}(1:L),
                 Dimensions.Dim{:draw}(1:2:1_000),
                 Dimensions.Dim{:chain}(1:nchains),
+                Dimensions.Dim{:bi}(2:(K + 1)),
+                Dimensions.Dim{:b_dim_2}(1:L),
             ),
         )
         attrs = Dict("mykey" => 5)

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -59,6 +59,18 @@ using InferenceObjects, DimensionalData, OffsetArrays, Test
         @test gdims isa NTuple{4,Dim}
         @test Dimensions.name(gdims) === (:draw, :chain, :c, :d)
         @test Dimensions.index(gdims) == (11:20, 0:3, -1:0, 2:4)
+
+        x = randn(2, 3)
+        InferenceObjects.generate_dims(x, :x; dims=(:a, :b))
+        @test_throws DimensionMismatch InferenceObjects.generate_dims(
+            x, :x; dims=(:a,), default_dims=[:b, :c]
+        )
+        @test_throws DimensionMismatch InferenceObjects.generate_dims(
+            x, :x; dims=(:a, :b), default_dims=[:c]
+        )
+        @test_throws DimensionMismatch InferenceObjects.generate_dims(
+            x, :x; dims=(:a, :b, :c), default_dims=[:c]
+        )
     end
 
     @testset "array_to_dimarray" begin

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -38,38 +38,38 @@ using InferenceObjects, DimensionalData, OffsetArrays, Test
     end
 
     @testset "generate_dims" begin
-        x = OffsetArray(randn(2, 3, 10, 4), -1:0, 2:4, 11:20, 0:3)
+        x = OffsetArray(randn(10, 4, 2, 3), 11:20, 0:3, -1:0, 2:4)
         gdims = @inferred NTuple{4,Dimensions.Dimension} InferenceObjects.generate_dims(
             x, :x
         )
         @test gdims isa NTuple{4,Dim}
         @test Dimensions.name(gdims) === (:x_dim_1, :x_dim_2, :x_dim_3, :x_dim_4)
-        @test Dimensions.index(gdims) == (-1:0, 2:4, 11:20, 0:3)
+        @test Dimensions.index(gdims) == (11:20, 0:3, -1:0, 2:4)
 
         gdims = @inferred NTuple{4,Dimensions.Dimension} InferenceObjects.generate_dims(
             x, :y; dims=(:a, :b)
         )
         @test gdims isa NTuple{4,Dim}
         @test Dimensions.name(gdims) === (:a, :b, :y_dim_3, :y_dim_4)
-        @test Dimensions.index(gdims) == (-1:0, 2:4, 11:20, 0:3)
+        @test Dimensions.index(gdims) == (11:20, 0:3, -1:0, 2:4)
 
         gdims = @inferred NTuple{4,Dimensions.Dimension} InferenceObjects.generate_dims(
             x, :z; dims=(:c, :d), default_dims=(:draw, :chain)
         )
         @test gdims isa NTuple{4,Dim}
-        @test Dimensions.name(gdims) === (:c, :d, :draw, :chain)
-        @test Dimensions.index(gdims) == (-1:0, 2:4, 11:20, 0:3)
+        @test Dimensions.name(gdims) === (:draw, :chain, :c, :d)
+        @test Dimensions.index(gdims) == (11:20, 0:3, -1:0, 2:4)
     end
 
     @testset "array_to_dimarray" begin
-        x = OffsetArray(randn(2, 3, 10, 4), -1:0, 2:4, 11:20, 0:3)
+        x = OffsetArray(randn(10, 4, 2, 3), 11:20, 0:3, -1:0, 2:4)
         da = @inferred DimArray InferenceObjects.array_to_dimarray(x, :x)
         @test da == x
         @test DimensionalData.name(da) === :x
         gdims = Dimensions.dims(da)
         @test gdims isa NTuple{4,Dim}
         @test Dimensions.name(gdims) === (:x_dim_1, :x_dim_2, :x_dim_3, :x_dim_4)
-        @test Dimensions.index(gdims) == (-1:0, 2:4, 11:20, 0:3)
+        @test Dimensions.index(gdims) == (11:20, 0:3, -1:0, 2:4)
 
         da = @inferred DimArray InferenceObjects.array_to_dimarray(x, :y; dims=(:a, :b))
         @test da == x
@@ -77,7 +77,7 @@ using InferenceObjects, DimensionalData, OffsetArrays, Test
         gdims = Dimensions.dims(da)
         @test gdims isa NTuple{4,Dim}
         @test Dimensions.name(gdims) === (:a, :b, :y_dim_3, :y_dim_4)
-        @test Dimensions.index(gdims) == (-1:0, 2:4, 11:20, 0:3)
+        @test Dimensions.index(gdims) == (11:20, 0:3, -1:0, 2:4)
 
         da = @inferred DimArray InferenceObjects.array_to_dimarray(
             x, :z; dims=(:c, :d), default_dims=(:draw, :chain)
@@ -86,8 +86,8 @@ using InferenceObjects, DimensionalData, OffsetArrays, Test
         @test DimensionalData.name(da) === :z
         gdims = Dimensions.dims(da)
         @test gdims isa NTuple{4,Dim}
-        @test Dimensions.name(gdims) === (:c, :d, :draw, :chain)
-        @test Dimensions.index(gdims) == (-1:0, 2:4, 11:20, 0:3)
+        @test Dimensions.name(gdims) === (:draw, :chain, :c, :d)
+        @test Dimensions.index(gdims) == (11:20, 0:3, -1:0, 2:4)
 
         v = randn(1_000)
         da = @inferred DimArray InferenceObjects.array_to_dimarray(

--- a/test/from_dict.jl
+++ b/test/from_dict.jl
@@ -8,9 +8,9 @@ using InferenceObjects, OrderedCollections, Test
 
     dicts = [
         "Dict{Symbol}" =>
-            Dict(Symbol(k) => randn(sz..., ndraws, nchains) for (k, sz) in pairs(sizes)),
+            Dict(Symbol(k) => randn(ndraws, nchains, sz...) for (k, sz) in pairs(sizes)),
         "OrderedDict{String}" =>
-            Dict(string(k) => randn(sz..., ndraws, nchains) for (k, sz) in pairs(sizes)),
+            Dict(string(k) => randn(ndraws, nchains, sz...) for (k, sz) in pairs(sizes)),
     ]
 
     @testset "posterior::$(type)" for (type, dict) in dicts

--- a/test/from_namedtuple.jl
+++ b/test/from_namedtuple.jl
@@ -66,4 +66,13 @@ using InferenceObjects, Test
             idata2, group, (:w, :v); library, dims, coords, default_dims=()
         )
     end
+
+    @testset "convert_to_inference_data with non-posterior `group`" begin
+        data = (x=3, y=randn(2))
+        idata = convert_to_inference_data(data; group=:observed_data)
+        @test issetequal(keys(idata), (:observed_data,))
+        @test issetequal(keys(idata.observed_data), (:x, :y))
+        @test idata.observed_data.x == fill(data.x)
+        @test idata.observed_data.y == data.y
+    end
 end

--- a/test/from_namedtuple.jl
+++ b/test/from_namedtuple.jl
@@ -8,11 +8,8 @@ using InferenceObjects, Test
 
     nts = [
         "NamedTuple" => map(sz -> randn(sz..., ndraws, nchains), sizes),
-        "Vector{NamedTuple}" => [map(sz -> randn(sz..., ndraws), sizes) for _ in 1:nchains],
-        "Matrix{NamedTuple}" =>
-            [map(sz -> randn(sz...), sizes) for _ in 1:ndraws, _ in 1:nchains],
         "Vector{Vector{NamedTuple}}" =>
-            [[map(sz -> randn(sz...), sizes) for _ in 1:ndraws] for _ in 1:nchains],
+            [[map(Base.splat(randn), sizes) for _ in 1:ndraws] for _ in 1:nchains],
     ]
 
     @testset "posterior::$(type)" for (type, nt) in nts

--- a/test/from_namedtuple.jl
+++ b/test/from_namedtuple.jl
@@ -7,7 +7,7 @@ using InferenceObjects, Test
     coords = (yx=["y1", "y2"], zx=1:3, zy=1:5)
 
     nts = [
-        "NamedTuple" => map(sz -> randn(sz..., ndraws, nchains), sizes),
+        "NamedTuple" => map(sz -> randn(ndraws, nchains, sz...), sizes),
         "Vector{Vector{NamedTuple}}" =>
             [[map(Base.splat(randn), sizes) for _ in 1:ndraws] for _ in 1:nchains],
     ]

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -1,7 +1,7 @@
 using InferenceObjects, DimensionalData
 
 function random_dim_array(var_name, dims, coords, T, default_dims=())
-    _dims = (dims..., default_dims...)
+    _dims = (default_dims..., dims...)
     _coords = NamedTuple{_dims}(getproperty.(Ref(coords), _dims))
     size = map(length, values(_coords))
     set = T isa Bool ? T : (T isa Integer ? (T(0):T(100)) : T)
@@ -111,7 +111,7 @@ function test_idata_group_correct(
         da = ds[name]
         @test DimensionalData.name(da) === name
         _dims = DimensionalData.dims(da)
-        _dim_names_exp = (get(dims, name, ())..., default_dims...)
+        _dim_names_exp = (default_dims..., get(dims, name, ())...)
         _dim_names = DimensionalData.name(_dims)
         @test issubset(_dim_names_exp, _dim_names)
         for dim in _dims

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,6 +11,20 @@ module TestSubModule end
         @test InferenceObjects.recursive_stack(1:5) == 1:5
     end
 
+    @testset "stack_draws" begin
+        draws = [(x=rand(), y=rand(2), z=randn(3, 4)) for _ in 1:10]
+        chain = @inferred InferenceObjects.stack_draws(draws)
+        @test chain isa NamedTuple{(:x, :y, :z)}
+        @test size.(values(chain)) == ((10,), (10, 2), (10, 3, 4))
+    end
+
+    @testset "stack_chains" begin
+        chains = [(x=rand(10), y=rand(10, 2), z=randn(10, 3, 4)) for _ in 1:5]
+        vals = @inferred InferenceObjects.stack_chains(chains)
+        @test vals isa NamedTuple{(:x, :y, :z)}
+        @test size.(values(vals)) == ((10, 5), (10, 5, 2), (10, 5, 3, 4))
+    end
+
     @testset "namedtuple_of_arrays" begin
         @test InferenceObjects.namedtuple_of_arrays((x=3, y=4)) === (x=3, y=4)
         @test InferenceObjects.namedtuple_of_arrays([(x=3, y=4), (x=5, y=6)]) ==


### PR DESCRIPTION
This PR changes the default dimension order from `(params..., draw, chain)` to `(draw, chain, params...)`. While this is a breaking change, no user code that indexes and permutes dimensions using dimension names instead of indices will be impacted.

This changes the ordering from that adopted in #8. The benefits are:
- All those as the ordering adopted in #8.
- Most analyses involve reductions over draws or draws and chains, which with column major arrays will generally be fastest with this ordering.
- Most plots involve slicing first by parameters and then by chains. So this layout is most natural for plotting
- A simple reshape forms a matrix with `(sample, param)`, which is easily converted to a table of draws and which can be an input to MLJ.

Downsides of this approach:
- We use a different stacking dimension when combining draws vs combining chains, so we can't just recursively stack. But this is probably safer anyways.
- Combining draws and chains is in general a little slower. This is just an up-front cost though and is minor.
- The ordering is not simply the reverse of Python ArviZ's, so when a Python ArviZ user loads a netCDF saved here in Python ArviZ, the dimension order won't match those in Python ArviZ. This isn't a problem, since ArviZ supports all dimension orders.