### PR TITLE
Remove Dataset getproperty overloads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Compat = "3.46.0, 4.2.0"
-DimensionalData = "0.23.1, 0.24"
+DimensionalData = "0.24"
 OffsetArrays = "1"
 OrderedCollections = "1"
 Tables = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -35,10 +35,6 @@ Dataset(data::Dataset) = data
 
 Base.parent(data::Dataset) = getfield(data, :data)
 
-Base.propertynames(data::Dataset) = keys(data)
-
-Base.getproperty(data::Dataset, k::Symbol) = getindex(data, k)
-
 function setattribute!(data::Dataset, k::AbstractString, value)
     setindex!(DimensionalData.metadata(data), value, k)
     return value


### PR DESCRIPTION
v0.24 of DimensionalData now uses `getproperty` syntax to access `DimArray`s within an `AbstractDimStack` same as we do, so these overloads are no longer necessary.