### PR TITLE
Implement `cat` for InferenceData

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,9 +74,3 @@ jobs:
           install-package: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
-          julia --project=docs -e '
-            using Documenter: DocMeta, doctest
-            using InferenceObjects
-            DocMeta.setdocmeta!(InferenceObjects, :DocTestSetup, :(using InferenceObjects); recursive=true)
-            doctest(InferenceObjects)'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,10 @@ DocMeta.setdocmeta!(
     InferenceObjects, :DocTestSetup, :(using InferenceObjects); recursive=true
 )
 
+doctestfilters = [
+    r"\s+\"created_at\" => .*",  # ignore timestamps in doctests
+]
+
 makedocs(;
     modules=[InferenceObjects, InferenceObjectsNetCDF],
     authors="Seth Axen <seth.axen@gmail.com> and contributors",
@@ -23,6 +27,7 @@ makedocs(;
         "InferenceData" => "inference_data.md",
         "Subpackages" => ["subpackages/inferenceobjectsnetcdf.md"],
     ],
+    doctestfilters=doctestfilters,
 )
 
 deploydocs(; repo="github.com/arviz-devs/InferenceObjects.jl", devbranch="main")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ makedocs(;
         "Subpackages" => ["subpackages/inferenceobjectsnetcdf.md"],
     ],
     doctestfilters=doctestfilters,
+    strict=Documenter.except(:missing_docs),
 )
 
 deploydocs(; repo="github.com/arviz-devs/InferenceObjects.jl", devbranch="main")

--- a/docs/src/inference_data.md
+++ b/docs/src/inference_data.md
@@ -40,5 +40,6 @@ from_namedtuple
 ## General functions
 
 ```@docs
+cat
 merge
 ```

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -231,12 +231,12 @@ end
 @generated _keys_and_types(::NamedTuple{keys,types}) where {keys,types} = (keys, types)
 
 """
-    merge(data::InferenceData, others::InferenceData...) -> InferenceData
+    merge(data::InferenceData...) -> InferenceData
 
 Merge [`InferenceData`](@ref) objects.
 
 The result contains all groups in `data` and `others`.
-If a group appears more than once, the one that occurs first is kept.
+If a group appears more than once, the one that occurs last is kept.
 """
 function Base.merge(data::InferenceData, others::InferenceData...)
     return InferenceData(Base.merge(groups(data), map(groups, others)...))

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -239,6 +239,26 @@ The result contains all groups in `data` and `others`.
 If a group appears more than once, the one that occurs last is kept.
 
 See also: [`cat`](@ref)
+
+# Examples
+
+Here we merge an `InferenceData` containing only a posterior group with one containing only
+a prior group to create a new one containing both groups.
+
+```jldoctest
+julia> idata1 = from_dict(Dict(:a => randn(100, 4, 3), :b => randn(100, 4)))
+InferenceData with groups:
+  > posterior
+
+julia> idata2 = from_dict(; prior=Dict(:a => randn(100, 1, 3), :c => randn(100, 1)))
+InferenceData with groups:
+  > prior
+
+julia> idata_merged = merge(idata1, idata2)
+InferenceData with groups:
+  > posterior
+  > prior
+```
 """
 function Base.merge(data::InferenceData, others::InferenceData...)
     return InferenceData(Base.merge(groups(data), map(groups, others)...))

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -370,6 +370,7 @@ and 1 layer:
 
 with metadata Dict{String, Any} with 1 entry:
   "created_at" => "2023-02-17T15:11:00.59"
+```
 """
 function Base.cat(data::InferenceData, others::InferenceData...; groups=keys(data), dims)
     groups_cat = map(groups) do k

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -313,9 +313,9 @@ with metadata Dict{String, Any} with 1 entry:
   "created_at" => "2023-02-17T18:47:29.679"
 ```
 
-We can also concatenate only a subset of groups and merge the rest, which is especially
-useful when some groups are present only in some of the `InferenceData` objects or will be
-identical in all of them:
+We can also concatenate only a subset of groups and merge the rest, which is useful when
+some groups are present only in some of the `InferenceData` objects or will be identical in
+all of them:
 
 ```jldoctest cat
 julia> observed_data = Dict(:y => randn(10));

--- a/test/inference_data.jl
+++ b/test/inference_data.jl
@@ -124,4 +124,16 @@ using InferenceObjects, DimensionalData, Test
             @test occursin("Dataset", text)
         end
     end
+
+    @testset "merge" begin
+        posterior2 = random_dataset(var_names, dims, coords, metadata, (;))
+        idata1 = InferenceData(; posterior=posterior)
+        idata2 = InferenceData(; posterior=posterior2, prior=prior)
+        idata3 = InferenceData(; observed_data=observed_data)
+        @test @inferred(merge(idata1, idata2)) ==
+            InferenceData(; posterior=posterior2, prior=prior)
+        @test @inferred(merge(idata2, idata1, idata3)) ==
+            InferenceData(; posterior=posterior, prior=prior, observed_data=observed_data)
+    end
+
 end


### PR DESCRIPTION
This PR implements `cat` for `InferenceData` inputs and better documents and tests `merge`. `cat` provides most of the functionality of `arviz.concat`.