### PR TITLE
Add MCMCDiagnosticTools integration

### DIFF
--- a/.github/workflows/Subpackage_CI.yml
+++ b/.github/workflows/Subpackage_CI.yml
@@ -52,14 +52,14 @@ jobs:
           Pkg.develop([Pkg.PackageSpec(; path="."),
                        Pkg.PackageSpec(; path="./lib/${{ matrix.subpackage }}")])
         shell: julia --color=yes {0}
-        with:
+        env:
           JULIA_PROJECT: ${{ runner.temp }}/monorepo
       - name: Run the tests
         run: |
           using Pkg
           Pkg.test("${{ matrix.subpackage }}"; coverage=true)
         shell: julia --color=yes {0}
-        with:
+        env:
           JULIA_PROJECT: ${{ runner.temp }}/monorepo
       - uses: julia-actions/julia-processcoverage@v1
         with:

--- a/.github/workflows/Subpackage_CI.yml
+++ b/.github/workflows/Subpackage_CI.yml
@@ -14,9 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
-env:
-  PROJECT_PATH: ${{ RUNNER_TEMP }}/monorepo
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -50,7 +47,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - name: Set up environment
-        shell: julia --project=${{ PROJECT_PATH }} {0}
+        shell: julia --project=${{ runner.temp }}/monorepo {0}
         run: |
           using Pkg;
           Pkg.develop([Pkg.PackageSpec(; path="."),
@@ -59,7 +56,7 @@ jobs:
         run: |
           using Pkg
           Pkg.test("${{ matrix.subpackage }}"; coverage=true)
-        shell: julia --color=yes --project=${{ PROJECT_PATH }} {0}
+        shell: julia --color=yes --project=${{ runner.temp }}/monorepo {0}
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: lib/${{ matrix.subpackage }}/src

--- a/.github/workflows/Subpackage_CI.yml
+++ b/.github/workflows/Subpackage_CI.yml
@@ -47,16 +47,20 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - name: Set up environment
-        shell: julia --project=${{ runner.temp }}/monorepo {0}
         run: |
           using Pkg;
           Pkg.develop([Pkg.PackageSpec(; path="."),
                        Pkg.PackageSpec(; path="./lib/${{ matrix.subpackage }}")])
+        shell: julia --color=yes {0}
+        with:
+          JULIA_PROJECT: ${{ runner.temp }}/monorepo
       - name: Run the tests
         run: |
           using Pkg
           Pkg.test("${{ matrix.subpackage }}"; coverage=true)
-        shell: julia --color=yes --project=${{ runner.temp }}/monorepo {0}
+        shell: julia --color=yes {0}
+        with:
+          JULIA_PROJECT: ${{ runner.temp }}/monorepo
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: lib/${{ matrix.subpackage }}/src

--- a/.github/workflows/Subpackage_CI.yml
+++ b/.github/workflows/Subpackage_CI.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
+env:
+  PROJECT_PATH: ${{ RUNNER_TEMP }}/monorepo
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -47,7 +50,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - name: Set up environment
-        shell: julia --project=monorepo {0}
+        shell: julia --project=${{ PROJECT_PATH }} {0}
         run: |
           using Pkg;
           Pkg.develop([Pkg.PackageSpec(; path="."),
@@ -56,7 +59,7 @@ jobs:
         run: |
           using Pkg
           Pkg.test("${{ matrix.subpackage }}"; coverage=true)
-        shell: julia --color=yes --project=monorepo {0}
+        shell: julia --color=yes --project=${{ PROJECT_PATH }} {0}
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: lib/${{ matrix.subpackage }}/src

--- a/.github/workflows/Subpackage_CI.yml
+++ b/.github/workflows/Subpackage_CI.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Set up environment
         run: |
           using Pkg;
+          Pkg.instantiate()
           Pkg.develop([Pkg.PackageSpec(; path="."),
                        Pkg.PackageSpec(; path="./lib/${{ matrix.subpackage }}")])
         shell: julia --color=yes {0}

--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,20 @@ version = "0.3.5"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[weakdeps]
+MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[extensions]
+InferenceObjectsMCMCDiagnosticToolsExt = ["MCMCDiagnosticTools", "Random"]
 
 [compat]
 Compat = "3.46.0, 4.2.0"
 DimensionalData = "0.24"
+MCMCDiagnosticTools = "0.3"
 OffsetArrays = "1"
 OrderedCollections = "1"
 Tables = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -20,17 +20,21 @@ InferenceObjectsMCMCDiagnosticToolsExt = ["MCMCDiagnosticTools", "Random"]
 [compat]
 Compat = "3.46.0, 4.2.0"
 DimensionalData = "0.24"
+EvoTrees = "0.14"
 MCMCDiagnosticTools = "0.3"
+MLJBase = "0.21"
 OffsetArrays = "1"
 OrderedCollections = "1"
 Tables = "1"
 julia = "1.6"
 
 [extras]
+EvoTrees = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
 MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "MCMCDiagnosticTools", "OffsetArrays", "OrderedCollections"]
+test = ["EvoTrees", "MCMCDiagnosticTools", "MLJBase", "OffsetArrays", "OrderedCollections", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.3.6"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 

--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,8 @@ MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["EvoTrees", "MCMCDiagnosticTools", "MLJBase", "OffsetArrays", "OrderedCollections", "Random", "Test"]
+test = ["EvoTrees", "MCMCDiagnosticTools", "MLJBase", "OffsetArrays", "OrderedCollections", "Random", "Statistics", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,8 @@ MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["EvoTrees", "MCMCDiagnosticTools", "MLJBase", "OffsetArrays", "OrderedCollections", "Test"]
+test = ["EvoTrees", "MCMCDiagnosticTools", "MLJBase", "OffsetArrays", "OrderedCollections", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -27,9 +27,10 @@ Tables = "1"
 julia = "1.6"
 
 [extras]
+MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OffsetArrays", "OrderedCollections"]
+test = ["Test", "MCMCDiagnosticTools", "OffsetArrays", "OrderedCollections"]

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl
@@ -1,0 +1,3 @@
+module InferenceObjectsMCMCDiagnosticToolsExt
+
+end  # module

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl
@@ -1,3 +1,18 @@
 module InferenceObjectsMCMCDiagnosticToolsExt
 
+using DimensionalData: DimensionalData, Dimensions, LookupArrays
+using InferenceObjects: InferenceObjects, EXTENSIONS_SUPPORTED
+using Random
+if EXTENSIONS_SUPPORTED
+    using MCMCDiagnosticTools: MCMCDiagnosticTools
+else  # using Requires
+    using ..MCMCDiagnosticTools: MCMCDiagnosticTools
+end
+
+include("utils.jl")
+include("bfmi.jl")
+include("ess_rhat.jl")
+include("mcse.jl")
+include("rstar.jl")
+
 end  # module

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/bfmi.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/bfmi.jl
@@ -1,0 +1,14 @@
+"""
+    bfmi(data::InferenceData) -> DimArray
+    bfmi(sample_stats::Dataset) -> DimArray
+
+Calculate the chainwise estimated Bayesian fraction of missing information (BFMI).
+"""
+function MCMCDiagnosticTools.bfmi(data::InferenceObjects.InferenceData)
+    return MCMCDiagnosticTools.bfmi(data.sample_stats)
+end
+function MCMCDiagnosticTools.bfmi(data::InferenceObjects.Dataset)
+    energy = data.energy
+    bfmi = MCMCDiagnosticTools.bfmi(energy; dims=Dimensions.dimnum(energy, :draw))
+    return Dimensions.rebuild(bfmi; refdims=())
+end

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/bfmi.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/bfmi.jl
@@ -9,6 +9,17 @@ function MCMCDiagnosticTools.bfmi(data::InferenceObjects.InferenceData)
 end
 function MCMCDiagnosticTools.bfmi(data::InferenceObjects.Dataset)
     energy = data.energy
-    bfmi = MCMCDiagnosticTools.bfmi(energy; dims=Dimensions.dimnum(energy, :draw))
-    return Dimensions.rebuild(bfmi; refdims=())
+    # bfmi uses diff, which drops the dimensions and breaks type-inferribility for
+    # dimensional arrays. So we drop the dimensions before calling bfmi and then
+    # rebuild the dimensional array afterwards.
+    bfmi = MCMCDiagnosticTools.bfmi(
+        DimensionalData.data(energy); dims=Dimensions.dimnum(energy, :draw)
+    )
+    return Dimensions.rebuild(
+        energy;
+        data=bfmi,
+        dims=(Dimensions.dims(energy, :chain),),
+        metadata=(),
+        name=DimensionalData.NoName(),
+    )
 end

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/ess_rhat.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/ess_rhat.jl
@@ -1,0 +1,54 @@
+"""
+    ess(data::InferenceData; kwargs...) -> Dataset
+    ess(data::Dataset; kwargs...) -> Dataset
+
+Calculate the effective sample size (ESS) for each parameter in the data.
+"""
+function MCMCDiagnosticTools.ess(data::InferenceObjects.InferenceData; kwargs...)
+    return MCMCDiagnosticTools.ess(data.posterior; kwargs...)
+end
+
+"""
+    rhat(data::InferenceData; kwargs...) -> Dataset
+    rhat(data::Dataset; kwargs...) -> Dataset
+
+Calculate the ``\\widehat{R}`` diagnostic for each parameter in the data.
+"""
+function MCMCDiagnosticTools.rhat(data::InferenceObjects.InferenceData; kwargs...)
+    return MCMCDiagnosticTools.rhat(data.posterior; kwargs...)
+end
+
+for f in (:ess, :rhat)
+    @eval begin
+        function MCMCDiagnosticTools.$f(data::InferenceObjects.Dataset; kwargs...)
+            ds = map(data) do var
+                return _from_marginals(
+                    var, MCMCDiagnosticTools.$f(_as_marginals(var); kwargs...)
+                )
+            end
+            return DimensionalData.rebuild(ds; metadata=DimensionalData.NoMetadata())
+        end
+    end
+end
+
+"""
+    ess_rhat(data::InferenceData; kwargs...) -> Dataset
+    ess_rhat(data::Dataset; kwargs...) -> Dataset
+
+Calculate the effective sample size (ESS) and ``\\widehat{R}`` diagnostic for each parameter
+in the data.
+"""
+function MCMCDiagnosticTools.ess_rhat(data::InferenceObjects.InferenceData; kwargs...)
+    return MCMCDiagnosticTools.ess_rhat(data.posterior; kwargs...)
+end
+function MCMCDiagnosticTools.ess_rhat(data::InferenceObjects.Dataset; kwargs...)
+    dim_diag = Dimensions.Dim{:_metric}([:ess, :rhat])
+    ds = map(DimensionalData.layers(data)) do var
+        ess, rhat = map(
+            Base.Fix1(_from_marginals, var),
+            MCMCDiagnosticTools.ess_rhat(_as_marginals(var); kwargs...),
+        )
+        return cat(ess, rhat; dims=dim_diag)
+    end
+    return InferenceObjects.Dataset(ds)
+end

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/mcse.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/mcse.jl
@@ -1,0 +1,15 @@
+"""
+    ess(data::InferenceData; kwargs...) -> Dataset
+    ess(data::Dataset; kwargs...) -> Dataset
+
+Calculate the Monte Carlo standard error (MCSE) for each parameter in the data.
+"""
+function MCMCDiagnosticTools.mcse(data::InferenceObjects.InferenceData; kwargs...)
+    return MCMCDiagnosticTools.mcse(data.posterior; kwargs...)
+end
+function MCMCDiagnosticTools.mcse(data::InferenceObjects.Dataset; kwargs...)
+    ds = map(data) do var
+        return _from_marginals(var, MCMCDiagnosticTools.mcse(_as_marginals(var); kwargs...))
+    end
+    return DimensionalData.rebuild(ds; metadata=DimensionalData.NoMetadata())
+end

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/rstar.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/rstar.jl
@@ -16,7 +16,7 @@ end
 function MCMCDiagnosticTools.rstar(
     rng::Random.AbstractRNG, clf, data::InferenceObjects.Dataset; kwargs...
 )
-    data_array = cat(map(DimensionalData.data ∘ _as_marginals, data)...; dims=3)
+    data_array = cat(map(_as_marginals, data)...; dims=3)
     return MCMCDiagnosticTools.rstar(rng, clf, data_array; kwargs...)
 end
 function MCMCDiagnosticTools.rstar(

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/rstar.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/rstar.jl
@@ -1,0 +1,26 @@
+"""
+    rstar(
+        rng::Random.AbstractRNG=Random.default_rng(),
+        classifier,
+        data::Union{InferenceData,Dataset};
+        kwargs...,
+    )
+
+Calculate the ``R^*`` diagnostic for the data.
+"""
+function MCMCDiagnosticTools.rstar(
+    rng::Random.AbstractRNG, clf, data::InferenceObjects.InferenceData; kwargs...
+)
+    return MCMCDiagnosticTools.rstar(rng, clf, data.posterior; kwargs...)
+end
+function MCMCDiagnosticTools.rstar(
+    rng::Random.AbstractRNG, clf, data::InferenceObjects.Dataset; kwargs...
+)
+    data_array = cat(map(DimensionalData.data ∘ _as_marginals, data)...; dims=3)
+    return MCMCDiagnosticTools.rstar(rng, clf, data_array; kwargs...)
+end
+function MCMCDiagnosticTools.rstar(
+    clf, data::Union{InferenceObjects.InferenceData,InferenceObjects.Dataset}; kwargs...
+)
+    return MCMCDiagnosticTools.rstar(Random.default_rng(), clf, data; kwargs...)
+end

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/utils.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/utils.jl
@@ -1,0 +1,18 @@
+function _as_marginals(data)
+    sample_dims = Dimensions.dims(data, InferenceObjects.DEFAULT_SAMPLE_DIMS)
+    param_dims = Dimensions.otherdims(data, sample_dims)
+    dims_combined = Dimensions.combinedims(sample_dims, param_dims)
+    data_perm = PermutedDimsArray(data, dims_combined)
+    data_reshape = reshape(
+        DimensionalData.data(data_perm), (size(data_perm, 1), size(data_perm, 2), :)
+    )
+    return data_reshape
+end
+
+function _from_marginals(data, marginals)
+    sample_dims = Dimensions.dims(data, InferenceObjects.DEFAULT_SAMPLE_DIMS)
+    param_dims = Dimensions.otherdims(data, sample_dims)
+    param_sizes = map(i -> size(data, i), Dimensions.dimnum(data, param_dims))
+    data_reshape = reshape(marginals, param_sizes)
+    return Dimensions.rebuild(data, data_reshape, param_dims)
+end

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/utils.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/utils.jl
@@ -1,18 +1,29 @@
+# reshape to (ndraws, nchains, prod(size)) and drop the dimensions
+# even though the dimensions would be preserved, it's easier to keep types inferrable and
+# reduce compile time by dropping the dimensions before calling diagnostics.
 function _as_marginals(data)
     sample_dims = Dimensions.dims(data, InferenceObjects.DEFAULT_SAMPLE_DIMS)
     param_dims = Dimensions.otherdims(data, sample_dims)
     dims_combined = Dimensions.combinedims(sample_dims, param_dims)
-    data_perm = PermutedDimsArray(data, dims_combined)
-    data_reshape = reshape(
-        DimensionalData.data(data_perm), (size(data_perm, 1), size(data_perm, 2), :)
-    )
+    data_perm = _unwrappermutedims(data, dims_combined)
+    data_reshape = reshape(data_perm, (size(data_perm, 1), size(data_perm, 2), :))
     return data_reshape
 end
 
+# reshape to (ndraws, nchains, size...) and add back the dimensions
 function _from_marginals(data, marginals)
     sample_dims = Dimensions.dims(data, InferenceObjects.DEFAULT_SAMPLE_DIMS)
     param_dims = Dimensions.otherdims(data, sample_dims)
     param_sizes = map(i -> size(data, i), Dimensions.dimnum(data, param_dims))
     data_reshape = reshape(marginals, param_sizes)
     return Dimensions.rebuild(data, data_reshape, param_dims)
+end
+
+# even though the permutation is const-propagated, this is not enough to make
+# PermuteDimsArray(data, perm) type-stable
+function _unwrappermutedims(da::DimensionalData.AbstractDimArray{T,N}, dims) where {T,N}
+    perm = Dimensions.dimnum(da, dims)
+    iperm = invperm(perm)
+    data = DimensionalData.data(da)
+    return PermutedDimsArray{T,N,(perm...,),(iperm...,),typeof(data)}(data)
 end

--- a/src/InferenceObjects.jl
+++ b/src/InferenceObjects.jl
@@ -5,6 +5,8 @@ using Dates: Dates
 using DimensionalData: DimensionalData, Dimensions, LookupArrays
 using Tables: Tables
 
+const EXTENSIONS_SUPPORTED = isdefined(Base, :get_extension)
+
 # groups that are officially listed in the schema
 const SCHEMA_GROUPS = (
     :posterior,
@@ -41,5 +43,13 @@ include("convert_dataset.jl")
 include("convert_inference_data.jl")
 include("from_namedtuple.jl")
 include("from_dict.jl")
+
+@static if !EXTENSIONS_SUPPORTED
+    function __init__()
+        Requires.@require MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0" begin
+            include("../ext/InferenceObjectsMCMCDiagnosticToolsExt.jl")
+        end
+    end
+end
 
 end # module

--- a/src/InferenceObjects.jl
+++ b/src/InferenceObjects.jl
@@ -44,10 +44,15 @@ include("convert_inference_data.jl")
 include("from_namedtuple.jl")
 include("from_dict.jl")
 
+if !EXTENSIONS_SUPPORTED
+    using Requires: @require
+end
 @static if !EXTENSIONS_SUPPORTED
     function __init__()
-        Requires.@require MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0" begin
-            include("../ext/InferenceObjectsMCMCDiagnosticToolsExt.jl")
+        @require MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0" begin
+            include(
+                "../ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl",
+            )
         end
     end
 end

--- a/test/mcmcdiagnostictools.jl
+++ b/test/mcmcdiagnostictools.jl
@@ -1,0 +1,95 @@
+using DimensionalData
+using EvoTrees
+using InferenceObjects
+using MCMCDiagnosticTools
+using MLJBase
+using Random
+using Statistics
+using Test
+
+@testset "MCMCDiagnosticTools integration" begin
+    nchains, ndraws = 4, 10
+    sizes = (x=(), y=(2,), z=(3, 5))
+    dims = (y=[:yx], z=[:zx, :zy])
+    coords = (yx=["y1", "y2"], zx=0:2, zy=1:5)
+    energy = randn(ndraws, nchains)
+    dict1 = Dict(Symbol(k) => randn(ndraws, nchains, sz...) for (k, sz) in pairs(sizes))
+    idata1 = from_dict(dict1; dims, coords, sample_stats=Dict(:energy => energy))
+    # permute dimensions to test that diagnostics are invariant to dimension order
+    post2 = map(idata1.posterior) do var
+        n = ndims(var)
+        permdims = ((3:n)..., 2, 1)
+        return permutedims(var, permdims)
+    end
+    sample_stats2 = map(permutedims, idata1.sample_stats)
+    idata2 = InferenceData(; posterior=post2, sample_stats=sample_stats2)
+
+    @testset for f in (ess, rhat, ess_rhat, mcse)
+        kinds = f === mcse ? (mean, std) : (:bulk, :basic)
+        @testset for kind in kinds
+            # currently `DimensionalData.layers` is not type-inferrable, so we can only
+            # infer that the return type is a `Dataset`
+            @test_broken @inferred f(idata1; kind)
+            metric = @inferred Dataset f(idata1; kind)
+            @test issetequal(keys(metric), keys(idata1.posterior))
+            @test metric ==
+                f(idata1.posterior; kind) ==
+                f(idata2; kind) ==
+                f(idata2.posterior; kind)
+            for k in keys(sizes)
+                @test all(
+                    hasdim(
+                        Dimensions.dims(metric[k]),
+                        otherdims(Dimensions.dims(idata1.posterior[k]), (:draw, :chain)),
+                    ),
+                )
+                if f === ess_rhat
+                    @test hasdim(metric, :_metric)
+                    @test lookup(metric, :_metric) == [:ess, :rhat]
+                    @test (
+                        ess=vec(parent(view(metric; _metric=At(:ess))[k])),
+                        rhat=vec(parent(view(metric; _metric=At(:rhat))[k])),
+                    ) == f(reshape(parent(idata1.posterior[k]), ndraws, nchains, :); kind)
+                else
+                    @test vec(parent(metric[k])) ≈
+                        f(reshape(parent(idata1.posterior[k]), ndraws, nchains, :); kind)
+                end
+            end
+        end
+    end
+
+    @testset "bfmi" begin
+        @inferred bfmi(idata1)
+        @inferred bfmi(idata1.sample_stats)
+        @test bfmi(idata1) ==
+            bfmi(idata1.sample_stats) ==
+            bfmi(energy; dims=1) ≈
+            bfmi(idata2) ==
+            bfmi(idata2.sample_stats)
+    end
+
+    @testset "rstar" begin
+        classifier = EvoTreeClassifier(; nrounds=100, eta=0.3)
+        @testset for subset in (0.7, 0.8)
+            rng = Random.seed!(123)
+            r1 = rstar(rng, classifier, idata1; subset)
+            rng = Random.seed!(123)
+            r2 = rstar(rng, classifier, idata1.posterior; subset)
+            rng = Random.seed!(123)
+            r3 = rstar(rng, classifier, idata2; subset)
+            rng = Random.seed!(123)
+            r4 = rstar(rng, classifier, idata2.posterior; subset)
+            rng = Random.seed!(123)
+            post_mat = cat(
+                map(var -> reshape(parent(var), ndraws, nchains, :), idata1.posterior)...;
+                dims=3,
+            )
+            r5 = rstar(rng, classifier, post_mat; subset)
+            Random.seed!(123)
+            r6 = rstar(classifier, idata1; subset)
+            Random.seed!(123)
+            r7 = rstar(classifier, idata1; subset)
+            @test r1 == r2 == r3 == r4 == r5 == r6 == r7
+        end
+    end
+end

--- a/test/mcmcdiagnostictools.jl
+++ b/test/mcmcdiagnostictools.jl
@@ -69,26 +69,26 @@ using Test
     end
 
     @testset "rstar" begin
-        classifier = EvoTreeClassifier(; nrounds=100, eta=0.3)
+        classifier(rng) = EvoTreeClassifier(; nrounds=100, eta=0.3, rng)
         @testset for subset in (0.7, 0.8)
             rng = Random.seed!(123)
-            r1 = rstar(rng, classifier, idata1; subset)
+            r1 = rstar(rng, classifier(rng), idata1; subset)
             rng = Random.seed!(123)
-            r2 = rstar(rng, classifier, idata1.posterior; subset)
+            r2 = rstar(rng, classifier(rng), idata1.posterior; subset)
             rng = Random.seed!(123)
-            r3 = rstar(rng, classifier, idata2; subset)
+            r3 = rstar(rng, classifier(rng), idata2; subset)
             rng = Random.seed!(123)
-            r4 = rstar(rng, classifier, idata2.posterior; subset)
+            r4 = rstar(rng, classifier(rng), idata2.posterior; subset)
             rng = Random.seed!(123)
             post_mat = cat(
                 map(var -> reshape(parent(var), ndraws, nchains, :), idata1.posterior)...;
                 dims=3,
             )
-            r5 = rstar(rng, classifier, post_mat; subset)
+            r5 = rstar(rng, classifier(rng), post_mat; subset)
             Random.seed!(123)
-            r6 = rstar(classifier, idata1; subset)
+            r6 = rstar(classifier(rng), idata1; subset)
             Random.seed!(123)
-            r7 = rstar(classifier, idata1; subset)
+            r7 = rstar(classifier(rng), idata1; subset)
             @test r1 == r2 == r3 == r4 == r5 == r6 == r7
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,6 @@ using InferenceObjects, Test
     include("convert_inference_data.jl")
     include("from_namedtuple.jl")
     include("from_dict.jl")
+
+    include("mcmcdiagnostictools.jl")
 end


### PR DESCRIPTION
This PR overloads the recommended diagnostic methods in MCMCDiagnosticTools to take `Dataset` and `InferenceData` inputs. This is implemented as a weak extension on Julia v1.9 and as a conditionally loaded module on older Julia versions.

Since these overloads are fundamental for ArviZ, it's a little awkward to bury them in an extension. Still, putting them anywhere else except MCMCDiagnosticTools would technically be type piracy. In the future it might make sense to move these to an MCMCDiagnosticTools extension.

Another bit of awkwardness is that ideally this extension would also contain a `summarystats` overload, whose default implementation uses MCMCDiagnosticTools, but the default also depends on an hdi function, which is not yet defined and should not live in the extension. For now `summarystats` will likely continue to live in ArviZ.

We could document the overloads here, but it's perhaps better to document that the overloads are made here and then actually document the overloads in ArviZ.jl itself.