### PR TITLE
Remove workaround for type-unstable PermutedDimsArray in DimensionalData

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/utils.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/utils.jl
@@ -5,7 +5,7 @@ function _as_marginals(data)
     sample_dims = Dimensions.dims(data, InferenceObjects.DEFAULT_SAMPLE_DIMS)
     param_dims = Dimensions.otherdims(data, sample_dims)
     dims_combined = Dimensions.combinedims(sample_dims, param_dims)
-    data_perm = _unwrappermutedims(data, dims_combined)
+    data_perm = DimensionalData.data(PermutedDimsArray(data, dims_combined))
     data_reshape = reshape(data_perm, (size(data_perm, 1), size(data_perm, 2), :))
     return data_reshape
 end
@@ -17,13 +17,4 @@ function _from_marginals(data, marginals)
     param_sizes = map(i -> size(data, i), Dimensions.dimnum(data, param_dims))
     data_reshape = reshape(marginals, param_sizes)
     return Dimensions.rebuild(data, data_reshape, param_dims)
-end
-
-# even though the permutation is const-propagated, this is not enough to make
-# PermuteDimsArray(data, perm) type-stable
-function _unwrappermutedims(da::DimensionalData.AbstractDimArray{T,N}, dims) where {T,N}
-    perm = Dimensions.dimnum(da, dims)
-    iperm = invperm(perm)
-    data = DimensionalData.data(da)
-    return PermutedDimsArray{T,N,(perm...,),(iperm...,),typeof(data)}(data)
 end


### PR DESCRIPTION
https://github.com/rafaqz/DimensionalData.jl/pull/476 made `PermutedDimsArray(::AbstractDimArray, Tuple{Vararg{Dimension}})` type-inferrable, so this PR removes our workaround.