### PR TITLE
Port PyCall conversions from ArviZ as an extension

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
+env:
+  PYTHON: "Conda" # use Julia's packaged Conda build for installing packages
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,16 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+      - name: set LD_PRELOAD path
+        run: |
+          # https://github.com/JuliaPy/PyCall.jl/issues/999
+          PYCALL_LIBSTD_PATH=$(julia -e '
+            using Pkg
+            Pkg.activate(; temp=true)
+            Pkg.add("PyCall")
+            using PyCall
+            joinpath(dirname(PyCall.libpython), "libstdc++.so.6")')
+          echo "LD_PRELOAD=${PYCALL_LIBSTD_PATH}" >> $GITHUB_ENV
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
@@ -62,11 +72,6 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/julia-buildpkg@v1
-      - name: set LD_PRELOAD path
-        run: |
-          # https://github.com/JuliaPy/PyCall.jl/issues/999
-          PYCALL_LIBSTD_PATH=$(julia -e 'using PyCall; joinpath(dirname(PyCall.libpython), "libstdc++.so.6")')
-          echo "LD_PRELOAD=${PYCALL_LIBSTD_PATH}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           using Pkg

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/julia-buildpkg@v1
+      - name: set LD_PRELOAD path
+        run: |
+          # https://github.com/JuliaPy/PyCall.jl/issues/999
+          PYCALL_LIBSTD_PATH=$(julia -e 'using PyCall; joinpath(dirname(PyCall.libpython), "libstdc++.so.6")')
+          echo "LD_PRELOAD=${PYCALL_LIBSTD_PATH}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           using Pkg

--- a/Project.toml
+++ b/Project.toml
@@ -7,16 +7,19 @@ version = "0.3.9"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [weakdeps]
 MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [extensions]
 InferenceObjectsMCMCDiagnosticToolsExt = ["MCMCDiagnosticTools", "Random"]
+InferenceObjectsPyCallExt = "PyCall"
 
 [compat]
 Compat = "3.46.0, 4.2.0"
@@ -26,6 +29,7 @@ MCMCDiagnosticTools = "0.3.4"
 MLJBase = "0.21"
 OffsetArrays = "1"
 OrderedCollections = "1"
+PyCall = "1.91.2"
 Requires = "0.5, 1"
 Tables = "1"
 julia = "1.6"
@@ -36,9 +40,10 @@ MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["EvoTrees", "MCMCDiagnosticTools", "MLJBase", "OffsetArrays", "OrderedCollections", "Random", "Statistics", "Test"]
+test = ["EvoTrees", "MCMCDiagnosticTools", "MLJBase", "OffsetArrays", "OrderedCollections", "PyCall", "Random", "Statistics", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/ext/InferenceObjectsPyCallExt/InferenceObjectsPyCallExt.jl
+++ b/ext/InferenceObjectsPyCallExt/InferenceObjectsPyCallExt.jl
@@ -1,0 +1,26 @@
+module InferenceObjectsPyCallExt
+
+if isdefined(Base, :get_extension)
+    using DimensionalData: DimensionalData, Dimensions
+    using InferenceObjects: InferenceObjects
+    using OrderedCollections: OrderedDict
+    using PyCall: PyCall
+else  # using Requires
+    using ..DimensionalData: DimensionalData, Dimensions
+    using ..InferenceObjects: InferenceObjects
+    using ..OrderedCollections: OrderedDict
+    using ..PyCall: PyCall
+end
+
+const _min_arviz_version = v"0.13.0"
+const arviz = PyCall.PyNULL()
+const xarray = PyCall.PyNULL()
+
+include("setup.jl")
+include("convert.jl")
+
+function __init__()
+    return initialize_arviz()
+end
+
+end  # module

--- a/ext/InferenceObjectsPyCallExt/convert.jl
+++ b/ext/InferenceObjectsPyCallExt/convert.jl
@@ -1,0 +1,108 @@
+PyCall.PyObject(data::InferenceObjects.Dataset) = _to_xarray(data)
+
+function Base.convert(::Type{InferenceObjects.Dataset}, obj::PyCall.PyObject)
+    return InferenceObjects.Dataset(_dimstack_from_xarray(obj))
+end
+
+function PyCall.PyObject(data::InferenceObjects.InferenceData)
+    return PyCall.pycall(
+        arviz.InferenceData,
+        PyCall.PyObject;
+        map(PyCall.PyObject, InferenceObjects.groups(data))...,
+    )
+end
+
+function InferenceObjects.convert_to_inference_data(
+    obj::PyCall.PyObject; dims=nothing, coords=nothing, kwargs...
+)
+    if PyCall.pyisinstance(obj, arviz.InferenceData)
+        group_names = obj.groups()
+        groups = (
+            Symbol(name) => convert(InferenceObjects.Dataset, getindex(obj, name)) for
+            name in group_names
+        )
+        return InferenceObjects.InferenceData(; groups...)
+    else
+        # Python ArviZ requires dims and coords be dicts matching to vectors
+        pydims = dims === nothing ? dims : Dict(k -> collect(dims[k]) for k in keys(dims))
+        pycoords =
+            dims === nothing ? dims : Dict(k -> collect(coords[k]) for k in keys(coords))
+        return arviz.convert_to_inference_data(obj; dims=pydims, coords=pycoords, kwargs...)
+    end
+end
+
+function _dimstack_from_xarray(o::PyCall.PyObject)
+    PyCall.pyisinstance(o, xarray.Dataset) ||
+        throw(ArgumentError("argument is not an `xarray.Dataset`."))
+    var_names = collect(o.data_vars)
+    data = [_dimarray_from_xarray(getindex(o, name)) for name in var_names]
+    metadata = OrderedDict{String,Any}(string(k) => v for (k, v) in o.attrs)
+    return DimensionalData.DimStack(data...; metadata)
+end
+
+function _dimarray_from_xarray(o::PyCall.PyObject)
+    PyCall.pyisinstance(o, xarray.DataArray) ||
+        throw(ArgumentError("argument is not an `xarray.DataArray`."))
+    name = Symbol(o.name)
+    data = _process_pyarray(o.to_numpy())
+    coords = PyCall.PyDict(o.coords)
+    dims = Tuple(
+        map(d -> _wrap_dims(Symbol(d), _process_pyarray(coords[d].values)), o.dims)
+    )
+    attrs = OrderedDict{String,Any}(string(k) => v for (k, v) in o.attrs)
+    metadata = isempty(attrs) ? DimensionalData.NoMetadata() : attrs
+    return DimensionalData.DimArray(data, dims; name, metadata)
+end
+
+_process_pyarray(x) = x
+# NOTE: sometimes strings fail to convert to Julia types, so we try to force them here
+function _process_pyarray(x::Union{PyCall.PyObject,<:AbstractVector{PyCall.PyObject}})
+    return map(z -> z isa PyCall.PyObject ? PyCall.PyAny(z)::Any : z, x)
+end
+
+# wrap dims in a `Dim`, converting to an AbstractRange if possible
+function _wrap_dims(name::Symbol, dims::AbstractVector{<:Real})
+    D = Dimensions.Dim{name}
+    start = dims[begin]
+    stop = dims[end]
+    n = length(dims)
+    step = (stop - start) / (n - 1)
+    isrange = all(Iterators.drop(eachindex(dims), 1)) do i
+        return (dims[i] - dims[i - 1]) ≈ step
+    end
+    return if isrange
+        if step == 1
+            D(UnitRange(start, stop))
+        else
+            D(range(start, stop; length=n))
+        end
+    else
+        D(dims)
+    end
+end
+_wrap_dims(name::Symbol, dims::AbstractVector) = Dimensions.Dim{name}(dims)
+
+function _to_xarray(data::DimensionalData.AbstractDimStack)
+    data_vars = Dict(pairs(map(_to_xarray, DimensionalData.layers(data))))
+    attrs = Dict(pairs(DimensionalData.metadata(data)))
+    return PyCall.pycall(xarray.Dataset, PyCall.PyObject, data_vars; attrs)
+end
+
+function _to_xarray(data::DimensionalData.AbstractDimArray)
+    var_name = DimensionalData.name(data)
+    data_dims = DimensionalData.dims(data)
+    dims = collect(DimensionalData.name(data_dims))
+    coords = Dict(zip(dims, DimensionalData.index(data_dims)))
+    default_dims = String[]
+    values = parent(data)
+    if Missing <: eltype(values)
+        # passing `missing` to Python causes the array to have a `PyCall.jlwrap` dtype
+        values = replace(values, missing => NaN)
+    end
+    metadata = DimensionalData.metadata(data)
+    da = arviz.numpy_to_data_array(values; var_name, dims, coords, default_dims)
+    if !isempty(metadata)
+        da.attrs = metadata
+    end
+    return da
+end

--- a/ext/InferenceObjectsPyCallExt/setup.jl
+++ b/ext/InferenceObjectsPyCallExt/setup.jl
@@ -1,0 +1,110 @@
+import_arviz() = _import_dependency("arviz", "arviz"; channel="conda-forge")
+
+function arviz_version()
+    v = arviz.__version__
+    try
+        VersionNumber(v)
+    catch ArgumentError
+        v, suff = splitext(v)
+        return VersionNumber(v * suff[2:end])
+    end
+end
+
+function check_needs_update(; update=true)
+    if arviz_version() < _min_arviz_version
+        @warn "ArviZ.jl only officially supports arviz version $(_min_arviz_version) or " *
+            "greater but found version $(arviz_version())."
+        if update
+            if update_arviz()
+                # yay, but we still already imported the old version
+                msg = """
+                Please rebuild ArviZ.jl with `using Pkg; Pkg.build("ArviZ")` and re-launch Julia
+                to continue.
+                """
+            else
+                msg = """
+                Could not automatically update arviz. Please manually update arviz, rebuild
+                ArviZ.jl with `using Pkg; Pkg.build("ArviZ")`, and then re-launch Julia to
+                continue.
+                """
+            end
+            @warn msg
+        end
+    end
+    return nothing
+end
+
+function initialize_arviz()
+    PyCall.ispynull(arviz) || return nothing
+    copy!(arviz, import_arviz())
+    check_needs_update(; update=true)
+
+    PyCall.pytype_mapping(arviz.InferenceData, InferenceObjects.InferenceData)
+
+    initialize_xarray()
+    initialize_numpy()
+    return nothing
+end
+
+function initialize_xarray()
+    PyCall.ispynull(xarray) || return nothing
+    copy!(xarray, _import_dependency("xarray", "xarray"; channel="conda-forge"))
+    _import_dependency("dask", "dask"; channel="conda-forge")
+    return nothing
+end
+
+function initialize_numpy()
+    # Trigger NumPy initialization, see https://github.com/JuliaPy/PyCall.jl/issues/744
+    PyCall.PyObject([true])
+    return nothing
+end
+
+function update_arviz()
+    # updating arviz can change other packages, so we always ask for permission
+    if _using_conda() && _isyes(Base.prompt("Try updating arviz using conda? [Y/n]"))
+        # this syntax isn't officially supported, but it works (for now)
+        try
+            PyCall.Conda.add("arviz>=$_min_arviz_version"; channel="conda-forge")
+            return true
+        catch e
+            println(e.msg)
+        end
+    end
+    if _has_pip() && _isyes(Base.prompt("Try updating arviz using pip? [Y/n]"))
+        # can't specify version lower bound, so update to latest
+        try
+            run(PyCall.python_cmd(`-m pip install --upgrade -- arviz`))
+            return true
+        catch e
+            println(e.msg)
+        end
+    end
+    return false
+end
+
+function _import_dependency(modulename, pkgname=modulename; channel=nothing)
+    try
+        return if channel === nothing
+            PyCall.pyimport_conda(modulename, pkgname)
+        else
+            PyCall.pyimport_conda(modulename, pkgname, channel)
+        end
+    catch e
+        if _has_pip() && _isyes(Base.prompt("Try installing $pkgname using pip? [Y/n]"))
+            # installing with pip is riskier, so we ask for permission
+            run(PyCall.python_cmd(`-m pip install -- $pkgname`))
+            return PyCall.pyimport(modulename)
+        end
+        # PyCall has a nice error message
+        throw(e)
+    end
+end
+
+_isyes(s) = isempty(s) || lowercase(strip(s)) ∈ ("y", "yes")
+_isyes(::Nothing) = true
+
+_using_conda() = PyCall.conda
+
+_has_pip() = _has_pymodule("pip")
+
+_has_pymodule(modulename) = !PyCall.ispynull(PyCall.pyimport_e(modulename))

--- a/src/InferenceObjects.jl
+++ b/src/InferenceObjects.jl
@@ -56,6 +56,9 @@ end
                 )
             end
         end
+        @require PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0" begin
+            include("../ext/InferenceObjectsPyCallExt/InferenceObjectsPyCallExt.jl")
+        end
     end
 end
 

--- a/test/pycall.jl
+++ b/test/pycall.jl
@@ -1,0 +1,87 @@
+using InferenceObjects, DimensionalData, PyCall, Test
+
+arviz = PyNULL()
+xarray = PyNULL()
+has_python_arviz = false
+
+try
+    copy!(arviz, pyimport("arviz"))
+    copy!(xarray, pyimport("xarray"))
+    global has_python_arviz = true
+catch e
+    e isa PyError || rethrow()
+    @warn "Python ArviZ could not be loaded in PyCall's Python environment, skipping PyCall tests"
+end
+
+has_python_arviz && @testset "PyCall integration" begin
+    @testset "xarray interop" begin
+        @testset "Dataset <-> xarray" begin
+            nchains = 4
+            ndraws = 100
+            nshared = 3
+            xdims = (:chain, :draw, :shared)
+            x = DimArray(randn(nchains, ndraws, nshared), xdims)
+            ydims = (:chain, :draw, Dim{:ydim1}(Any["a", "b"]), :shared)
+            y = DimArray(randn(nchains, ndraws, 2, nshared), ydims)
+            metadata = Dict("prop1" => "val1", "prop2" => "val2")
+            ds = Dataset((; x, y); metadata)
+            o = PyObject(ds)
+            @test o isa PyObject
+            @test pyisinstance(o, xarray.Dataset)
+
+            @test issetequal(Symbol.(o.coords.keys()), (:chain, :draw, :shared, :ydim1))
+            for (dim, coord) in o.coords.items()
+                @test collect(coord.values) == DimensionalData.index(ds, Symbol(dim))
+            end
+
+            variables = Dict(collect(o.data_vars.variables.items()))
+            @test "x" ∈ keys(variables)
+            @test x == variables["x"].values
+            @test variables["x"].dims == String.(xdims)
+
+            @test "y" ∈ keys(variables)
+            @test y == variables["y"].values
+            @test variables["y"].dims == ("chain", "draw", "ydim1", "shared")
+
+            # check that the Python object accesses the underlying Julia array
+            x[1] = 1
+            @test x == variables["x"].values
+
+            ds2 = convert(Dataset, o)
+            @test ds2 isa Dataset
+            @test ds2.x ≈ ds.x
+            @test ds2.y ≈ ds.y
+            dims1 = sort(collect(DimensionalData.dims(ds)); by=DimensionalData.name)
+            dims2 = sort(collect(DimensionalData.dims(ds2)); by=DimensionalData.name)
+            for (dim1, dim2) in zip(dims1, dims2)
+                @test DimensionalData.name(dim1) === DimensionalData.name(dim2)
+                @test DimensionalData.index(dim1) == DimensionalData.index(dim2)
+                if DimensionalData.index(dim1) isa AbstractRange
+                    @test DimensionalData.index(dim2) isa AbstractRange
+                end
+            end
+            @test DimensionalData.metadata(ds2) == DimensionalData.metadata(ds)
+        end
+
+        @testset "InferenceData <-> PyObject" begin
+            idata1 = random_data()
+            pyidata1 = PyObject(idata1)
+            @test pyidata1 isa PyObject
+            @test pyisinstance(pyidata1, arviz.InferenceData)
+            idata2 = convert(InferenceData, pyidata1)
+            # drop observed_data, since it has zero-dim arrays, which are unsupported by
+            # xarray
+            idata1 = idata1[filter(!=(:observed_data), keys(idata1))]
+            idata2 = idata2[filter(!=(:observed_data), keys(idata2))]
+            test_idata_approx_equal(idata2, idata1)
+        end
+
+        @testset "convert_to_inference_data(obj::PyObject)" begin
+            data = Dict(:z => randn(4, 100, 10))
+            idata1 = convert_to_inference_data(data)
+            idata2 = convert_to_inference_data(PyObject(data))
+            @test idata2 isa InferenceData
+            @test idata2.posterior.z ≈ collect(idata1.posterior.z)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,5 @@ using InferenceObjects, Test
     include("from_dict.jl")
 
     include("mcmcdiagnostictools.jl")
+    include("pycall.jl")
 end


### PR DESCRIPTION
ArviZ implements the following interconversions:
- `Dataset` => `xarray.Dataset`
- `InferenceData` <=> `arviz.InferenceData`

This PR ports these interconversions directly here. The idea is that similar converters would also be provided for PythonCall.jl and to avoid what is technically type piracy.

The argument against this extension is that in principle other Python packages might implement the InferenceData spec, and then such automated conversions are bad.