### PR TITLE
Update docs to use Documenter v1

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,3 +6,6 @@ MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 PosteriorStats = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,7 @@ makedocs(;
         "InferenceData" => "inference_data.md",
     ],
     doctestfilters=doctestfilters,
-    strict=Documenter.except(:missing_docs),
+    warnonly=:missing_docs,
 )
 
 # run doctests on extensions

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,7 @@ doctestfilters = [
 makedocs(;
     modules=[InferenceObjects],
     authors="Seth Axen <seth.axen@gmail.com> and contributors",
-    repo="https://github.com/arviz-devs/InferenceObjects.jl/blob/{commit}{path}#{line}",
+    repo=Remotes.GitHub("arviz-devs", "InferenceObjects.jl"),
     sitename="InferenceObjects.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",


### PR DESCRIPTION
- Set Documenter compat to v1
- Change usage of `strict` to `warnonly`
- Explicitly set repo to GitHub
