### PR TITLE
Add missing method to make rebuild/set work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -30,6 +30,14 @@ struct Dataset{K,T,N,L,D<:DimensionalData.AbstractDimStack{K,T,N,L}} <:
     data::D
 end
 
+function Dataset{K,T,N}(
+    data::L, dims, refdims, layerdims, metadata, layermetadata
+) where {K,T,N,L}
+    data = DimensionalData.DimStack{K,T,N}(
+        data, dims, refdims, layerdims, metadata, layermetadata
+    )
+    return Dataset{K,T,N,L,typeof(data)}(data)
+end
 Dataset(args...; kwargs...) = Dataset(DimensionalData.DimStack(args...; kwargs...))
 Dataset(data::Dataset) = data
 

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -109,6 +109,20 @@ using InferenceObjects, DimensionalData, Test
             @test_deprecated InferenceObjects.setattribute!(dscopy, :prop3, "val4")
             @test InferenceObjects.attributes(dscopy)["prop3"] == "val4"
         end
+
+        @testset "DimensionalData.rebuild" begin
+            ds2 = DimensionalData.rebuild(ds; data=(; x=zero(x), y))
+            @test ds2 isa Dataset
+            @test iszero(ds2.x)
+            @test ds2.y == y
+        end
+
+        @testset "DimensionalData.set" begin
+            ds2 = DimensionalData.set(ds; ydim1=LookupArrays.Sampled([-2, 2]))
+            @test ds2 isa Dataset
+            @test DimensionalData.lookup(ds2, :ydim1) == [-2, 2]
+            @test DimensionalData.data(ds2) == DimensionalData.data(ds)
+        end
     end
 
     @testset "namedtuple_to_dataset" begin


### PR DESCRIPTION
This PR adds a missing constructor method for `Dataset` required for DimensionalData's `rebuild` and `set` methods to work.