### PR TITLE
Replace deprecated key2dim with name2dim

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.1"
+version = "0.4.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/InferenceObjects.jl
+++ b/src/InferenceObjects.jl
@@ -26,7 +26,7 @@ const SCHEMA_GROUPS = (
     :warmup_log_likelihood,
 )
 const SCHEMA_GROUPS_DICT = Dict(n => i for (i, n) in enumerate(SCHEMA_GROUPS))
-const DEFAULT_SAMPLE_DIMS = Dimensions.key2dim((:draw, :chain))
+const DEFAULT_SAMPLE_DIMS = Dimensions.name2dim((:draw, :chain))
 const DEFAULT_DRAW_DIM = 1
 const DEFAULT_CHAIN_DIM = 2
 

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,10 +1,10 @@
 has_all_sample_dims(dims) = all(Dimensions.hasdim(dims, DEFAULT_SAMPLE_DIMS))
 
-# Like Dimensions.key2dim but doesn't allow users to inject their own dimensions using
+# Like Dimensions.name2dim but doesn't allow users to inject their own dimensions using
 # Dimensions.@dim. See https://github.com/arviz-devs/InferenceObjects.jl/issues/37
-_key2dim(d::Symbol) = Dimensions.Dim{d}(LookupArrays.NoLookup())
-_key2dim(d::Tuple) = map(_key2dim, d)
-_key2dim(d) = d
+_name2dim(d::Symbol) = Dimensions.Dim{d}(LookupArrays.NoLookup())
+_name2dim(d::Tuple) = map(_name2dim, d)
+_name2dim(d) = d
 
 # make sure dim has a lookup value accessible with `val`
 _valdim(d) = d
@@ -30,7 +30,7 @@ Convert `dim`, `coords`, and `axis` to a `Dimension` object.
   - `axis`: A default axis to be used if `coords` and `dim` indices are not provided.
 """
 function as_dimension(dim, coords, axis)
-    cdim = _valdim(_key2dim(dim))
+    cdim = _valdim(_name2dim(dim))
     val = LookupArrays.val(cdim)
     inds = val isa Union{Colon,LookupArrays.NoLookup} ? axis : val
     coords_inds = get(coords, Dimensions.name(cdim), inds)
@@ -64,7 +64,7 @@ Generate `DimensionsionalData.Dimension` objects for each dimension of `array`.
 function generate_dims(array, name; dims=(), coords=(;), default_dims=())
     num_default_dims = length(default_dims)
     if length(dims) + num_default_dims > ndims(array)
-        dim_names = Dimensions.name(_key2dim((default_dims..., dims...)))
+        dim_names = Dimensions.name(_name2dim((default_dims..., dims...)))
         throw(
             DimensionMismatch(
                 "Provided dimensions $dim_names more than dimensions of array: $(ndims(array))",

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -26,14 +26,14 @@ Dimensions.@dim foo "foo"
         ))
     end
 
-    @testset "_key2dim" begin
+    @testset "_name2dim" begin
         @testset for k in (:chain, :draw, :foo)
-            @test InferenceObjects._key2dim(k) === Dim{k}(NoLookup())
-            @test @inferred(InferenceObjects._key2dim(Dim{k})) === Dim{k}
-            @test @inferred(InferenceObjects._key2dim(Dim{k}())) === Dim{k}()
-            @test @inferred(InferenceObjects._key2dim(Dim{k}(1:4))) == Dim{k}(1:4)
+            @test InferenceObjects._name2dim(k) === Dim{k}(NoLookup())
+            @test @inferred(InferenceObjects._name2dim(Dim{k})) === Dim{k}
+            @test @inferred(InferenceObjects._name2dim(Dim{k}())) === Dim{k}()
+            @test @inferred(InferenceObjects._name2dim(Dim{k}(1:4))) == Dim{k}(1:4)
         end
-        @test InferenceObjects._key2dim((:chain, :draw, :foo)) ===
+        @test InferenceObjects._name2dim((:chain, :draw, :foo)) ===
             (Dim{:chain}(NoLookup()), Dim{:draw}(NoLookup()), Dim{:foo}(NoLookup()))
     end
 


### PR DESCRIPTION
`DimensionalData.key2dim` is deprecated and replaced with `name2dim`. This updates our usage and also the naming of an internal function based on `name2dim`.