### PR TITLE
Temporarily remove standard libs as weak deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.4.5"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [weakdeps]

--- a/Project.toml
+++ b/Project.toml
@@ -14,11 +14,10 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 PosteriorStats = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [extensions]
-InferenceObjectsMCMCDiagnosticToolsExt = ["MCMCDiagnosticTools", "Random"]
+InferenceObjectsMCMCDiagnosticToolsExt = "MCMCDiagnosticTools"
 InferenceObjectsNCDatasetsExt = "NCDatasets"
 InferenceObjectsPosteriorStatsExt = ["PosteriorStats", "StatsBase"]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl
@@ -3,14 +3,12 @@ module InferenceObjectsMCMCDiagnosticToolsExt
 using Base: @doc
 if isdefined(Base, :get_extension)
     using DimensionalData: DimensionalData, Dimensions, LookupArrays
-    using InferenceObjects: InferenceObjects
+    using InferenceObjects: InferenceObjects, Random
     using MCMCDiagnosticTools: MCMCDiagnosticTools
-    using Random: Random
 else  # using Requires
     using ..DimensionalData: DimensionalData, Dimensions, LookupArrays
-    using ..InferenceObjects: InferenceObjects
+    using ..InferenceObjects: InferenceObjects, Random
     using ..MCMCDiagnosticTools: MCMCDiagnosticTools
-    using ..Random: Random
 end
 
 include("utils.jl")

--- a/src/InferenceObjects.jl
+++ b/src/InferenceObjects.jl
@@ -2,6 +2,7 @@ module InferenceObjects
 
 using Dates: Dates
 using DimensionalData: DimensionalData, Dimensions, LookupArrays
+using Random: Random
 using Tables: Tables
 
 const EXTENSIONS_SUPPORTED = isdefined(Base, :get_extension)


### PR DESCRIPTION
As noted in https://github.com/arviz-devs/InferenceObjects.jl/pull/86#issuecomment-2453467436, currently our MCMCDiagnosticTools extension will fail to load unless a user explicitly loads Random, since it is in the stdlib. This is due to a bug in v1.11 described in https://github.com/JuliaLang/julia/issues/56426. A fix for this will hopefully will be backported to v1.11.2.

This PR simply makes Random a full dependency always instead of a weak dep. After the bug is fixed in Julia, this PR should be reverted.