### PR TITLE
Add docs interlinks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ArviZExampleData = "2f96bb34-afd9-46ae-bcd0-9b2d4372fe3c"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 InferenceObjects = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
@@ -9,3 +10,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Documenter = "1"
+DocumenterInterLinks = "1"

--- a/docs/inventories/DimensionalData.toml
+++ b/docs/inventories/DimensionalData.toml
@@ -1,0 +1,14 @@
+# DocInventory version 1
+project = "DimensionalData.jl"
+version = "0.29.4"
+
+# NOTE: trimmed to just the pages we link to
+[[std.doc]]
+dispname = "Selectors"
+name = "selectors"
+uri = "selectors"
+
+[[std.doc]]
+dispname = "DimStacks"
+name = "dimstacks"
+uri = "stacks"

--- a/docs/inventories/IntervalSets.toml
+++ b/docs/inventories/IntervalSets.toml
@@ -1,0 +1,8 @@
+# DocInventory version 1
+project = "IntervalSets.jl"
+version = "0.7.10"
+
+# NOTE: trimmed to just the API functions we link to
+[[jl.type]]
+name = "IntervalSets.AbstractInterval"
+uri = "api/#$"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,16 @@
 using InferenceObjects
 using Documenter
+using DocumenterInterLinks
 using NCDatasets: NCDatasets  # load extension
 
 DocMeta.setdocmeta!(
     InferenceObjects, :DocTestSetup, :(using InferenceObjects); recursive=true
+)
+
+links = InterLinks(
+    "NCDatasets" => "https://alexander-barth.github.io/NCDatasets.jl/stable/",
+    "PosteriorStats" => "https://julia.arviz.org/PosteriorStats/stable/",
+    "MCMCDiagnosticTools" => "https://julia.arviz.org/MCMCDiagnosticTools/stable/",
 )
 
 doctestfilters = [
@@ -28,6 +35,7 @@ makedocs(;
     ],
     doctestfilters=doctestfilters,
     warnonly=:missing_docs,
+    plugins=[links],
 )
 
 # run doctests on extensions

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,15 @@ DocMeta.setdocmeta!(
 )
 
 links = InterLinks(
+    "arviz" => "https://python.arviz.org/en/stable/",
+    "DimensionalData" => (
+        "https://rafaqz.github.io/DimensionalData.jl/stable/",
+        joinpath(@__DIR__, "inventories", "DimensionalData.toml"),
+    ),
+    "IntervalSets" => (
+        "https://juliamath.github.io/IntervalSets.jl/stable/",
+        joinpath(@__DIR__, "inventories", "IntervalSets.toml"),
+    ),
     "NCDatasets" => "https://alexander-barth.github.io/NCDatasets.jl/stable/",
     "PosteriorStats" => "https://julia.arviz.org/PosteriorStats/stable/",
     "MCMCDiagnosticTools" => "https://julia.arviz.org/MCMCDiagnosticTools/stable/",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,10 @@
 using InferenceObjects
 using Documenter
 using DocumenterInterLinks
+using MCMCDiagnosticTools: MCMCDiagnosticTools  # load extension
 using NCDatasets: NCDatasets  # load extension
+using PosteriorStats: PosteriorStats  # load extension
+using StatsBase: StatsBase  # load extension
 
 DocMeta.setdocmeta!(
     InferenceObjects, :DocTestSetup, :(using InferenceObjects); recursive=true
@@ -18,7 +21,11 @@ doctestfilters = [
 ]
 
 makedocs(;
-    modules=[InferenceObjects],
+    modules=[
+        InferenceObjects,
+        Base.get_extension(InferenceObjects, :InferenceObjectsMCMCDiagnosticToolsExt),
+        Base.get_extension(InferenceObjects, :InferenceObjectsPosteriorStatsExt),
+    ],
     authors="Seth Axen <seth.axen@gmail.com> and contributors",
     repo=Remotes.GitHub("arviz-devs", "InferenceObjects.jl"),
     sitename="InferenceObjects.jl",
@@ -32,6 +39,10 @@ makedocs(;
         "Home" => "index.md",
         "Dataset" => "dataset.md",
         "InferenceData" => "inference_data.md",
+        "Extensions" => [
+            "MCMCDiagnosticTools" => "extensions/mcmcdiagnostictools.md",
+            "PosteriorStats" => "extensions/posteriorstats.md",
+        ],
     ],
     doctestfilters=doctestfilters,
     warnonly=:missing_docs,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -68,4 +68,6 @@ for extended_pkg in (MCMCDiagnosticTools, PosteriorStats)
     doctest(mod; manual=false)
 end
 
-deploydocs(; repo="github.com/arviz-devs/InferenceObjects.jl", devbranch="main")
+deploydocs(;
+    repo="github.com/arviz-devs/InferenceObjects.jl", devbranch="main", push_preview=true
+)

--- a/docs/src/dataset.md
+++ b/docs/src/dataset.md
@@ -20,7 +20,7 @@ namedtuple_to_dataset
 ## DimensionalData
 
 As a `DimensionalData.AbstractDimStack`, `Dataset` also implements the `AbstractDimStack` API and can be used like a `DimStack`.
-See [DimensionalData's documentation](https://rafaqz.github.io/DimensionalData.jl/stable/) for example usage.
+See [DimensionalData's documentation](@extref DimensionalData dimstacks) for example usage.
 
 ## Tables inteface
 

--- a/docs/src/extensions/mcmcdiagnostictools.md
+++ b/docs/src/extensions/mcmcdiagnostictools.md
@@ -1,0 +1,12 @@
+# Extension of MCMCDiagnosticTools
+
+The following methods of [MCMCDiagnosticTools.jl](https://julia.arviz.org/MCMCDiagnosticTools) are extended by this package.
+
+```@index
+Modules = [MCMCDiagnosticTools]
+```
+
+```@autodocs
+Modules = [Base.get_extension(InferenceObjects, :InferenceObjectsMCMCDiagnosticToolsExt)]
+Private = false
+```

--- a/docs/src/extensions/posteriorstats.md
+++ b/docs/src/extensions/posteriorstats.md
@@ -1,0 +1,16 @@
+# Extension of PosteriorStats
+
+The following methods of [PosteriorStats.jl](https://julia.arviz.org/PosteriorStats) are extended by this package.
+
+```@index
+Modules = [
+    Base.get_extension(InferenceObjects, :InferenceObjectsPosteriorStatsExt),
+    PosteriorStats,
+    StatsBase,
+]
+```
+
+```@autodocs
+Modules = [Base.get_extension(InferenceObjects, :InferenceObjectsPosteriorStatsExt)]
+Private = false
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ CurrentModule = InferenceObjects
 
 # InferenceObjects
 
-InferenceObjects.jl is a Julia implementation of the [InferenceData schema](https://python.arviz.org/en/latest/schema/schema.html) for storing results of Bayesian inference.
+InferenceObjects.jl is a Julia implementation of the [InferenceData schema](@extref arviz schema) for storing results of Bayesian inference.
 Its purpose is to serve the following three goals:
 1. Usefulness in the analysis of Bayesian inference results.
 2. Reproducibility of Bayesian inference analysis.

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/InferenceObjectsMCMCDiagnosticToolsExt.jl
@@ -5,6 +5,10 @@ using DimensionalData: DimensionalData, Dimensions, LookupArrays
 using InferenceObjects: InferenceObjects, Random
 using MCMCDiagnosticTools: MCMCDiagnosticTools
 
+import MCMCDiagnosticTools: bfmi, ess_rhat, mcse, rstar
+
+export bfmi, ess_rhat, mcse, rstar
+
 maplayers = isdefined(DimensionalData, :maplayers) ? DimensionalData.maplayers : map
 
 include("utils.jl")

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/bfmi.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/bfmi.jl
@@ -3,6 +3,8 @@
     bfmi(sample_stats::Dataset) -> DimArray
 
 Calculate the chainwise estimated Bayesian fraction of missing information (BFMI).
+
+See [`MCMCDiagnosticTools.bfmi`](@extref) for more details.
 """
 function MCMCDiagnosticTools.bfmi(data::InferenceObjects.InferenceData)
     return MCMCDiagnosticTools.bfmi(data.sample_stats)

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/ess_rhat.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/ess_rhat.jl
@@ -3,6 +3,9 @@
     ess(data::Dataset; kwargs...) -> Dataset
 
 Calculate the effective sample size (ESS) for each parameter in the data.
+
+For more details and a description of the `kwargs`, see
+[`MCMCDiagnosticTools.ess`](@extref).
 """
 function MCMCDiagnosticTools.ess(data::InferenceObjects.InferenceData; kwargs...)
     return MCMCDiagnosticTools.ess(data.posterior; kwargs...)
@@ -13,6 +16,9 @@ end
     rhat(data::Dataset; kwargs...) -> Dataset
 
 Calculate the ``\\widehat{R}`` diagnostic for each parameter in the data.
+
+For more details and a description of the `kwargs`, see
+[`MCMCDiagnosticTools.rhat`](@extref).
 """
 function MCMCDiagnosticTools.rhat(data::InferenceObjects.InferenceData; kwargs...)
     return MCMCDiagnosticTools.rhat(data.posterior; kwargs...)
@@ -35,6 +41,9 @@ end
 
 Calculate the effective sample size (ESS) and ``\\widehat{R}`` diagnostic for each parameter
 in the data.
+
+For more details and a description of the `kwargs`, see
+[`MCMCDiagnosticTools.ess_rhat`](@extref).
 """
 function MCMCDiagnosticTools.ess_rhat(data::InferenceObjects.InferenceData; kwargs...)
     return MCMCDiagnosticTools.ess_rhat(data.posterior; kwargs...)

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/mcse.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/mcse.jl
@@ -3,6 +3,9 @@
     mcse(data::Dataset; kwargs...) -> Dataset
 
 Calculate the Monte Carlo standard error (MCSE) for each parameter in the data.
+
+For more details and a description of the `kwargs`, see
+[`MCMCDiagnosticTools.mcse`](@extref).
 """
 function MCMCDiagnosticTools.mcse(data::InferenceObjects.InferenceData; kwargs...)
     return MCMCDiagnosticTools.mcse(data.posterior; kwargs...)

--- a/ext/InferenceObjectsMCMCDiagnosticToolsExt/rstar.jl
+++ b/ext/InferenceObjectsMCMCDiagnosticToolsExt/rstar.jl
@@ -7,6 +7,9 @@
     )
 
 Calculate the ``R^*`` diagnostic for the data.
+
+For a description of the `classifier` and `kwargs`, see
+[`MCMCDiagnosticTools.rstar`](@extref).
 """
 function MCMCDiagnosticTools.rstar(
     rng::Random.AbstractRNG, clf, data::InferenceObjects.InferenceData; kwargs...

--- a/ext/InferenceObjectsPosteriorStatsExt/InferenceObjectsPosteriorStatsExt.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/InferenceObjectsPosteriorStatsExt.jl
@@ -6,6 +6,11 @@ using InferenceObjects: InferenceObjects
 using PosteriorStats: PosteriorStats
 using StatsBase: StatsBase
 
+import PosteriorStats: hdi, loo, loo_pit, r2_score, summarize, waic
+import StatsBase: summarystats
+
+export hdi, loo, loo_pit, r2_score, summarize, waic, summarystats
+
 include("utils.jl")
 include("hdi.jl")
 include("loo.jl")

--- a/ext/InferenceObjectsPosteriorStatsExt/hdi.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/hdi.jl
@@ -10,6 +10,8 @@ end
     hdi(data::Dataset; kwargs...) -> Dataset
 
 Calculate the highest density interval (HDI) for each parameter in the data.
+
+For more details and a description of the `kwargs`, see [`PosteriorStats.hdi`](@extref).
 """
 function PosteriorStats.hdi(data::InferenceObjects.InferenceData; kwargs...)
     return PosteriorStats.hdi(data.posterior; kwargs...)

--- a/ext/InferenceObjectsPosteriorStatsExt/loo.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/loo.jl
@@ -6,6 +6,8 @@ Compute PSIS-LOO from log-likelihood values in `data`.
 
 If more than one log-likelihood variable is present, then `var_name` must be provided.
 
+For more details and a description of the `kwargs`, see [`PosteriorStats.loo`](@extref).
+
 # Examples
 
 Calculate PSIS-LOO of a model:

--- a/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
@@ -9,7 +9,10 @@ Compute LOO-PIT values using existing normalized log LOO importance weights.
     the only observed data variable is used.
   - `y_pred_name`: Name of posterior predictive variable in `idata.posterior_predictive`.
     If not provided, then `y_name` is used.
-  - `kwargs`: Remaining keywords are forwarded to the base method of `loo_pit`.
+  - `kwargs`: Remaining keywords are forwarded to the base method
+    [`PosteriorStats.loo_pit`](@extref).
+
+See [`PosteriorStats.loo_pit`](@extref) for more details.
 
 # Examples
 
@@ -69,7 +72,9 @@ Compute LOO-PIT from groups in `idata` using PSIS-LOO.
     _likelihood_ values. If an array, it must have the same data dimensions as the
     corresponding log-likelihood variable. If not provided, then this is estimated using
     `ess`.
-  - `kwargs`: Remaining keywords are forwarded to the base method of `loo_pit`.
+  - `kwargs`: Remaining keywords are forwarded to [`PosteriorStats.loo_pit`](@extref).
+
+See [`PosteriorStats.loo_pit`](@extref) for more details.
 
 # Examples
 

--- a/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
@@ -23,9 +23,9 @@ julia> idata = load_example_data("centered_eight");
 julia> loo_result = loo(idata; var_name=:obs);
 
 julia> loo_pit(idata, loo_result.psis_result.log_weights; y_name=:obs)
-╭───────────────────────────────────────────╮
-│ 8-element DimArray{Float64,1} loo_pit_obs │
-├───────────────────────────────────────────┴──────────────────────────── dims ┐
+╭────────────────────────────────────────────╮
+│ 8-element DimArray{Float64, 1} loo_pit_obs │
+├────────────────────────────────────────────┴─────────────────────────── dims ┐
   ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
 └──────────────────────────────────────────────────────────────────────────────┘
  "Choate"            0.943511
@@ -81,9 +81,9 @@ julia> using ArviZExampleData, PosteriorStats
 julia> idata = load_example_data("centered_eight");
 
 julia> loo_pit(idata; y_name=:obs)
-╭───────────────────────────────────────────╮
-│ 8-element DimArray{Float64,1} loo_pit_obs │
-├───────────────────────────────────────────┴──────────────────────────── dims ┐
+╭────────────────────────────────────────────╮
+│ 8-element DimArray{Float64, 1} loo_pit_obs │
+├────────────────────────────────────────────┴─────────────────────────── dims ┐
   ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
 └──────────────────────────────────────────────────────────────────────────────┘
  "Choate"            0.943511

--- a/ext/InferenceObjectsPosteriorStatsExt/r2_score.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/r2_score.jl
@@ -10,6 +10,8 @@ Compute ``R²`` from `idata`, automatically formatting the predictions to the co
   - `y_pred_name`: Name of posterior predictive variable in `idata.posterior_predictive`.
     If not provided, then `y_name` is used.
 
+See [`PosteriorStats.r2_score`](@extref) for more details.
+
 # Examples
 
 ```jldoctest

--- a/ext/InferenceObjectsPosteriorStatsExt/summarize.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/summarize.jl
@@ -2,7 +2,8 @@
     summarystats(data::InferenceData; group=:posterior, kwargs...) -> SummaryStats
     summarystats(data::Dataset; kwargs...) -> SummaryStats
 
-Compute default summary statistics for the data using `summarize`.
+Compute default summary statistics for the data using
+[`PosteriorStats.summarize`](@ref PosteriorStats.summarize(::InferenceData)).
 """
 function StatsBase.summarystats(data::InferenceObjects.InferenceData; kwargs...)
     return PosteriorStats.summarize(data; kwargs...)
@@ -18,7 +19,7 @@ end
 Compute summary statistics for the data using the provided functions.
 
 For verbose variable labels, provide `compat_labels=false`. For details on `stats_funs` and
-`kwargs`, see the main `summarize` method.
+`kwargs`, see [`PosteriorStats.summarize`](@extref).
 
 # Examples
 

--- a/ext/InferenceObjectsPosteriorStatsExt/waic.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/waic.jl
@@ -6,6 +6,8 @@ Compute WAIC from log-likelihood values in `data`.
 
 If more than one log-likelihood variable is present, then `var_name` must be provided.
 
+See [`PosteriorStats.waic`](@extref) for more details.
+
 # Examples
 
 Calculate WAIC of a model:

--- a/src/convert_dataset.jl
+++ b/src/convert_dataset.jl
@@ -4,7 +4,7 @@ Base.convert(::Type{Dataset}, obj::Dataset) = obj
 """
     convert_to_dataset(obj; group = :posterior, kwargs...) -> Dataset
 
-Convert a supported object to a `Dataset`.
+Convert a supported object to a [`Dataset`](@ref).
 
 In most cases, this function calls [`convert_to_inference_data`](@ref) and returns the
 corresponding `group`.

--- a/src/convert_inference_data.jl
+++ b/src/convert_inference_data.jl
@@ -1,7 +1,7 @@
 """
     convert(::Type{InferenceData}, obj)
 
-Convert `obj` to an `InferenceData`.
+Convert `obj` to an [`InferenceData`](@ref).
 
 `obj` can be any type for which [`convert_to_inference_data`](@ref) is defined.
 """
@@ -23,7 +23,7 @@ See [`convert_to_dataset`](@ref)
 # Arguments
 
   - `obj` can be many objects. Basic supported types are:
-    
+
       + [`InferenceData`](@ref): return unchanged
       + [`Dataset`](@ref)/`DimensionalData.AbstractDimStack`: add to `InferenceData` as the only
         group
@@ -40,7 +40,7 @@ More specific types may be documented separately.
 
   - `dims`: a collection mapping variable names to collections of objects containing
     dimension names. Acceptable such objects are:
-    
+
       + `Symbol`: dimension name
       + `Type{<:DimensionsionalData.Dimension}`: dimension type
       + `DimensionsionalData.Dimension`: dimension, potentially with indices

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -3,8 +3,7 @@
 
 Container of dimensional arrays sharing some dimensions.
 
-This type is an
-[`DimensionalData.AbstractDimStack`](https://rafaqz.github.io/DimensionalData.jl/stable/stacks)
+This type is an [`DimensionalData.AbstractDimStack`](@extref DimensionalData dimstacks)
 that implements the same interface as `DimensionalData.DimStack` and has identical usage.
 
 # Constructors

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -7,10 +7,6 @@ This type is an
 [`DimensionalData.AbstractDimStack`](https://rafaqz.github.io/DimensionalData.jl/stable/stacks)
 that implements the same interface as `DimensionalData.DimStack` and has identical usage.
 
-When a `Dataset` is passed to Python, it is converted to an `xarray.Dataset` without copying
-the data. That is, the Python object shares the same memory as the Julia object. However,
-if an `xarray.Dataset` is passed to Julia, its data must be copied.
-
 # Constructors
 
     Dataset(data::DimensionalData.AbstractDimArray...)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -4,7 +4,7 @@
 Container of dimensional arrays sharing some dimensions.
 
 This type is an
-[`DimensionalData.AbstractDimStack`](https://rafaqz.github.io/DimensionalData.jl/stable/reference/#DimensionalData.AbstractDimStack)
+[`DimensionalData.AbstractDimStack`](https://rafaqz.github.io/DimensionalData.jl/stable/stacks)
 that implements the same interface as `DimensionalData.DimStack` and has identical usage.
 
 When a `Dataset` is passed to Python, it is converted to an `xarray.Dataset` without copying
@@ -64,8 +64,8 @@ Any non-array values will be converted to a 0-dimensional array.
     dataset, in addition to defaults. Values should be JSON serializable.
   - `library::Union{String,Module}`: library used for performing inference. Will be attached
     to the `attrs` metadata.
-  - `dims`: a collection mapping variable names to collections of objects containing dimension
-    names. Acceptable such objects are:
+  - `dims`: a collection mapping variable names to collections of objects containing
+    dimension names. Acceptable such objects are:
       + `Symbol`: dimension name
       + `Type{<:DimensionsionalData.Dimension}`: dimension type
       + `DimensionsionalData.Dimension`: dimension, potentially with indices

--- a/src/from_dict.jl
+++ b/src/from_dict.jl
@@ -1,7 +1,7 @@
 """
     from_dict(posterior::AbstractDict; kwargs...) -> InferenceData
 
-Convert a `Dict` to an `InferenceData`.
+Convert a dictionary to an [`InferenceData`](@ref).
 
 # Arguments
 
@@ -62,8 +62,9 @@ end
 """
     convert_to_inference_data(obj::AbstractDict; kwargs...) -> InferenceData
 
-Convert `obj` to an [`InferenceData`](@ref). See [`from_namedtuple`](@ref) for a description
-of `obj` possibilities and `kwargs`.
+Convert a dictionary to an [`InferenceData`](@ref).
+
+See [`from_dict`](@ref) for a description of `obj` possibilities and `kwargs`.
 """
 function convert_to_inference_data(data::AbstractDict; group=:posterior, kwargs...)
     group = Symbol(group)

--- a/src/from_namedtuple.jl
+++ b/src/from_namedtuple.jl
@@ -10,7 +10,7 @@
         kwargs...
     ) -> InferenceData
 
-Convert a `NamedTuple` or container of `NamedTuple`s to an `InferenceData`.
+Convert a `NamedTuple` or container of `NamedTuple`s to an [`InferenceData`](@ref).
 
 If containers are passed, they are flattened into a single `NamedTuple` with array elements
 whose first dimensions correspond to the dimensions of the containers.

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -3,7 +3,7 @@
 
 Container for inference data storage using DimensionalData.
 
-This object implements the [InferenceData schema](https://python.arviz.org/en/latest/schema/schema.html).
+This object implements the [InferenceData schema](@extref arviz schema).
 
 Internally, groups are stored in a `NamedTuple`, which can be accessed using
 `parent(::InferenceData)`.
@@ -61,9 +61,8 @@ Return a new [`InferenceData`](@ref) containing the specified groups sliced to t
 specified `coords`.
 
 `coords` specifies a dimension name mapping to an index, a
-[`DimensionalData.Selector`](https://rafaqz.github.io/DimensionalData.jl/stable/selectors),
-or an
 [`IntervalSets.AbstractInterval`](https://juliamath.github.io/IntervalSets.jl/stable/api/#IntervalSets.AbstractInterval).
+[`DimensionalData.Selector`](@extref DimensionalData selectors), or an
 
 If one or more groups lack the specified dimension, a warning is raised but can be ignored.
 All groups that contain the dimension must also contain the specified indices, or an

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -61,8 +61,8 @@ Return a new [`InferenceData`](@ref) containing the specified groups sliced to t
 specified `coords`.
 
 `coords` specifies a dimension name mapping to an index, a
-[`IntervalSets.AbstractInterval`](https://juliamath.github.io/IntervalSets.jl/stable/api/#IntervalSets.AbstractInterval).
 [`DimensionalData.Selector`](@extref DimensionalData selectors), or an
+[`IntervalSets.AbstractInterval`](@extref).
 
 If one or more groups lack the specified dimension, a warning is raised but can be ignored.
 All groups that contain the dimension must also contain the specified indices, or an

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -17,8 +17,8 @@ Construct an inference data from either a `NamedTuple` or keyword arguments of g
 
 Groups must be [`Dataset`](@ref) objects.
 
-Instead of directly creating an `InferenceData`, use the exported `from_xyz` functions or
-[`convert_to_inference_data`](@ref).
+Instead of directly creating an [`InferenceData`](@ref), use the exported `from_xyz`
+functions or [`convert_to_inference_data`](@ref).
 """
 struct InferenceData{group_names,group_types<:Tuple{Vararg{Dataset}}}
     groups::NamedTuple{group_names,group_types}
@@ -57,10 +57,13 @@ Base.getproperty(data::InferenceData, k::Symbol) = getproperty(parent(data), k)
     Base.getindex(data::InferenceData, groups::Symbol; coords...) -> Dataset
     Base.getindex(data::InferenceData, groups; coords...) -> InferenceData
 
-Return a new `InferenceData` containing the specified groups sliced to the specified coords.
+Return a new [`InferenceData`](@ref) containing the specified groups sliced to the
+specified `coords`.
 
-`coords` specifies a dimension name mapping to an index, a `DimensionalData.Selector`, or
-an `IntervalSets.AbstractInterval`.
+`coords` specifies a dimension name mapping to an index, a
+[`DimensionalData.Selector`](https://rafaqz.github.io/DimensionalData.jl/stable/selectors),
+or an
+[`IntervalSets.AbstractInterval`](https://juliamath.github.io/IntervalSets.jl/stable/api/#IntervalSets.AbstractInterval).
 
 If one or more groups lack the specified dimension, a warning is raised but can be ignored.
 All groups that contain the dimension must also contain the specified indices, or an
@@ -116,8 +119,8 @@ with metadata Dict{String, Any} with 1 entry:
   "created_at" => "2022-08-11T11:15:21.4"
 ```
 
-Select data from just the posterior, returning a `Dataset` if the indices index more than
-one element from any of the variables:
+Select data from just the posterior, returning a [`Dataset`](@ref) if the indices index more
+than one element from any of the variables:
 
 ```@repl getindex
 julia> idata[:observed_data, id=At(["a"])]
@@ -164,7 +167,7 @@ end
 """
     Base.setindex(data::InferenceData, group::Dataset, name::Symbol) -> InferenceData
 
-Create a new `InferenceData` containing the `group` with the specified `name`.
+Create a new [`InferenceData`](@ref) containing the `group` with the specified `name`.
 
 If a group with `name` is already in `data`, it is replaced.
 """

--- a/src/io.jl
+++ b/src/io.jl
@@ -3,7 +3,7 @@
 
 Load an [`InferenceData`](@ref) from an unopened NetCDF file.
 
-Remaining `kwargs` are passed to [`NCDatasets.NCDataset`](https://alexander-barth.github.io/NCDatasets.jl/stable/dataset/#NCDatasets.NCDataset).
+Remaining `kwargs` are passed to [`NCDatasets.NCDataset`](@extref).
 This method loads data eagerly. To instead load data lazily, pass an opened `NCDataset` to
 `from_netcdf`.
 
@@ -71,8 +71,7 @@ Write `data` to a NetCDF file.
 group the data represents.
 
 `dest` specifies either the path to the NetCDF file or an opened NetCDF file.
-If `dest` is a path, remaining `kwargs` are passed to
-[`NCDatasets.NCDataset`](https://alexander-barth.github.io/NCDatasets.jl/stable/dataset/#NCDatasets.NCDataset).
+If `dest` is a path, remaining `kwargs` are passed to [`NCDatasets.NCDataset`](@extref).
 
 !!! note
     This method requires that NCDatasets is loaded before it can be used.


### PR DESCRIPTION
This PR uses DocumenterInterLinks to link to other package's docs, when applicable.