### PR TITLE
Fix broken doctests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.8"
+version = "0.4.9"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,7 @@ links = InterLinks(
         "https://juliamath.github.io/IntervalSets.jl/stable/",
         joinpath(@__DIR__, "inventories", "IntervalSets.toml"),
     ),
-    "NCDatasets" => "https://alexander-barth.github.io/NCDatasets.jl/stable/",
+    "NCDatasets" => "https://juliageo.org/NCDatasets.jl/stable/",
     "PosteriorStats" => "https://julia.arviz.org/PosteriorStats/stable/",
     "MCMCDiagnosticTools" => "https://julia.arviz.org/MCMCDiagnosticTools/stable/",
 )

--- a/ext/InferenceObjectsPosteriorStatsExt/loo.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/loo.jl
@@ -20,13 +20,13 @@ julia> idata = load_example_data("centered_eight");
 julia> loo(idata)
 PSISLOOResult with estimates
  elpd  elpd_mcse    p  p_mcse
-  -31        1.4  0.9    0.34
+  -31        1.4  0.9    0.33
 
 and PSISResult with 500 draws, 4 chains, and 8 parameters
 Pareto shape (k) diagnostic values:
                     Count      Min. ESS
- (-Inf, 0.5]  good  6 (75.0%)  135
-  (0.5, 0.7]  okay  2 (25.0%)  421
+ (-Inf, 0.5]  good  4 (50.0%)  270
+  (0.5, 0.7]  okay  4 (50.0%)  307
 ```
 """
 function PosteriorStats.loo(

--- a/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
@@ -26,8 +26,7 @@ julia> idata = load_example_data("centered_eight");
 julia> loo_result = loo(idata; var_name=:obs);
 
 julia> loo_pit(idata, loo_result.psis_result.log_weights; y_name=:obs)
-╭────────────────────────────────────────────╮
-│ 8-element DimArray{Float64, 1} loo_pit_obs │
+┌ 8-element DimArray{Float64, 1} loo_pit_obs ┐
 ├────────────────────────────────────────────┴─────────────────────────── dims ┐
   ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -86,8 +85,7 @@ julia> using ArviZExampleData, PosteriorStats
 julia> idata = load_example_data("centered_eight");
 
 julia> loo_pit(idata; y_name=:obs)
-╭────────────────────────────────────────────╮
-│ 8-element DimArray{Float64, 1} loo_pit_obs │
+┌ 8-element DimArray{Float64, 1} loo_pit_obs ┐
 ├────────────────────────────────────────────┴─────────────────────────── dims ┐
   ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
 └──────────────────────────────────────────────────────────────────────────────┘

--- a/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
@@ -31,14 +31,14 @@ julia> loo_pit(idata, loo_result.psis_result.log_weights; y_name=:obs)
 ├────────────────────────────────────────────┴─────────────────────────── dims ┐
   ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
 └──────────────────────────────────────────────────────────────────────────────┘
- "Choate"            0.943511
- "Deerfield"         0.63797
- "Phillips Andover"  0.316697
- "Phillips Exeter"   0.582252
- "Hotchkiss"         0.295321
- "Lawrenceville"     0.403318
- "St. Paul's"        0.902508
- "Mt. Hermon"        0.655275
+ "Choate"            0.942759
+ "Deerfield"         0.641057
+ "Phillips Andover"  0.32729
+ "Phillips Exeter"   0.581451
+ "Hotchkiss"         0.288523
+ "Lawrenceville"     0.393741
+ "St. Paul's"        0.886175
+ "Mt. Hermon"        0.638821
 ```
 """
 function PosteriorStats.loo_pit(
@@ -91,14 +91,14 @@ julia> loo_pit(idata; y_name=:obs)
 ├────────────────────────────────────────────┴─────────────────────────── dims ┐
   ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
 └──────────────────────────────────────────────────────────────────────────────┘
- "Choate"            0.943511
- "Deerfield"         0.63797
- "Phillips Andover"  0.316697
- "Phillips Exeter"   0.582252
- "Hotchkiss"         0.295321
- "Lawrenceville"     0.403318
- "St. Paul's"        0.902508
- "Mt. Hermon"        0.655275
+ "Choate"            0.942759
+ "Deerfield"         0.641057
+ "Phillips Andover"  0.32729
+ "Phillips Exeter"   0.581451
+ "Hotchkiss"         0.288523
+ "Lawrenceville"     0.393741
+ "St. Paul's"        0.886175
+ "Mt. Hermon"        0.638821
 ```
 """
 function PosteriorStats.loo_pit(

--- a/ext/InferenceObjectsPosteriorStatsExt/summarize.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/summarize.jl
@@ -34,16 +34,16 @@ julia> data = load_example_data("centered_eight");
 julia> summarize(data)
 SummaryStats
                           mean  std  hdi_3%  hdi_97%  mcse_mean  mcse_std  ess ⋯
- mu                        4.5  3.5  -1.62     10.7        0.23      0.11      ⋯
- theta[Choate]             6.5  5.9  -4.56     17.1        0.30      0.29      ⋯
- theta[Deerfield]          5.0  4.9  -4.31     14.3        0.23      0.17      ⋯
- theta[Phillips Andover]   3.9  5.7  -7.77     13.7        0.23      0.28      ⋯
- theta[Phillips Exeter]    4.9  5.0  -4.49     14.7        0.26      0.17      ⋯
- theta[Hotchkiss]          3.7  5.0  -6.47     11.7        0.25      0.16      ⋯
- theta[Lawrenceville]      4.0  5.2  -7.04     12.2        0.22      0.22      ⋯
- theta[St. Paul's]         6.6  5.1  -3.09     16.3        0.30      0.19      ⋯
- theta[Mt. Hermon]         4.8  5.7  -5.86     16.0        0.26      0.25      ⋯
- tau                       4.1  3.1   0.896     9.67       0.26      0.17      ⋯
+ mu                        4.2  3.3  -1.61     10.3        0.21     0.088      ⋯
+ theta[Choate]             6.4  5.9  -3.68     17.9        0.25     0.20       ⋯
+ theta[Deerfield]          5.0  4.9  -4.98     13.4        0.21     0.15       ⋯
+ theta[Phillips Andover]   3.4  5.4  -7.54     12.9        0.23     0.17       ⋯
+ theta[Phillips Exeter]    4.8  5.2  -5.11     14.1        0.21     0.21       ⋯
+ theta[Hotchkiss]          3.5  4.8  -6.12     12.0        0.25     0.15       ⋯
+ theta[Lawrenceville]      3.7  5.2  -6.50     12.7        0.22     0.21       ⋯
+ theta[St. Paul's]         6.5  5.2  -2.67     16.9        0.22     0.15       ⋯
+ theta[Mt. Hermon]         4.8  5.7  -5.97     15.4        0.24     0.23       ⋯
+ tau                       4.3  3.0   0.715     9.41       0.22     0.14       ⋯
                                                                3 columns omitted
 ```
 
@@ -54,14 +54,14 @@ parameters:
 julia> summarize(data.posterior[(:theta,)], (:mean, :std) => mean_and_std, median, mad)
 SummaryStats
                           mean   std  median   mad
- theta[Choate]            6.46  5.87    6.08  4.64
- theta[Deerfield]         5.03  4.88    5.01  4.96
- theta[Phillips Andover]  3.94  5.69    4.23  4.67
- theta[Phillips Exeter]   4.87  5.01    5.02  4.82
- theta[Hotchkiss]         3.67  4.96    3.89  4.70
- theta[Lawrenceville]     3.97  5.19    4.14  4.64
- theta[St. Paul's]        6.58  5.11    6.07  4.47
- theta[Mt. Hermon]        4.77  5.74    4.71  4.95
+ theta[Choate]            6.42  5.85    5.80  4.95
+ theta[Deerfield]         4.95  4.91    5.02  4.68
+ theta[Phillips Andover]  3.42  5.43    3.74  4.84
+ theta[Phillips Exeter]   4.75  5.25    4.69  4.84
+ theta[Hotchkiss]         3.45  4.78    3.62  4.55
+ theta[Lawrenceville]     3.66  5.23    3.90  4.88
+ theta[St. Paul's]        6.51  5.24    6.09  4.57
+ theta[Mt. Hermon]        4.82  5.70    4.65  4.89
 ```
 """
 function PosteriorStats.summarize(

--- a/ext/InferenceObjectsPosteriorStatsExt/waic.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/waic.jl
@@ -20,7 +20,7 @@ julia> idata = load_example_data("centered_eight");
 julia> waic(idata)
 WAICResult with estimates
  elpd  elpd_mcse    p  p_mcse
-  -31        1.4  0.9    0.33
+  -31        1.4  0.9    0.32
 ```
 """
 function PosteriorStats.waic(

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -312,7 +312,7 @@ julia> idata_cat1.posterior
   :b eltype: Float64 dims: draw, chain size: 100×8
 ├────────────────────────────────────────────────── metadata ┤
   Dict{String, Any} with 1 entry:
-  "created_at" => "2024-03-11T14:10:48.434"
+  "created_at" => "2025-02-04T10:49:16.704"
 ```
 
 Alternatively, we can concatenate along a new `run` dimension, which will be created.
@@ -334,7 +334,7 @@ julia> idata_cat2.posterior
   :b eltype: Float64 dims: draw, chain, run size: 100×4×2
 ├──────────────────────────────────────────────────────────── metadata ┤
   Dict{String, Any} with 1 entry:
-  "created_at" => "2024-03-11T14:10:48.434"
+  "created_at" => "2025-02-04T10:49:16.704"
 ```
 
 We can also concatenate only a subset of groups and merge the rest, which is useful when
@@ -366,7 +366,7 @@ julia> idata_cat3.posterior
   :b eltype: Float64 dims: draw, chain, run size: 100×4×2
 ├──────────────────────────────────────────────────────────── metadata ┤
   Dict{String, Any} with 1 entry:
-  "created_at" => "2024-03-11T14:10:48.434"
+  "created_at" => "2025-02-04T10:49:16.704"
 
 julia> idata_cat3.observed_data
 ┌ 10-element Dataset ┐
@@ -376,7 +376,7 @@ julia> idata_cat3.observed_data
   :y eltype: Float64 dims: y_dim_1 size: 10
 ├────────────────────────────────────────────┴ metadata ┐
   Dict{String, Any} with 1 entry:
-  "created_at" => "2024-03-11T14:10:53.539"
+  "created_at" => "2025-02-04T10:49:16.71"
 ```
 """
 function Base.cat(data::InferenceData, others::InferenceData...; groups=keys(data), dims)

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -302,8 +302,7 @@ InferenceData with groups:
   > posterior
 
 julia> idata_cat1.posterior
-╭─────────────────╮
-│ 100×8×3 Dataset │
+┌ 100×8×3 Dataset ┐
 ├─────────────────┴──────────────────────────────────── dims ┐
   ↓ draw ,
   → chain,
@@ -324,8 +323,7 @@ InferenceData with groups:
   > posterior
 
 julia> idata_cat2.posterior
-╭───────────────────╮
-│ 100×4×3×2 Dataset │
+┌ 100×4×3×2 Dataset ┐
 ├───────────────────┴─────────────────────────────────── dims ┐
   ↓ draw ,
   → chain,
@@ -357,8 +355,7 @@ InferenceData with groups:
   > observed_data
 
 julia> idata_cat3.posterior
-╭───────────────────╮
-│ 100×4×3×2 Dataset │
+┌ 100×4×3×2 Dataset ┐
 ├───────────────────┴─────────────────────────────────── dims ┐
   ↓ draw ,
   → chain,
@@ -372,8 +369,7 @@ julia> idata_cat3.posterior
   "created_at" => "2024-03-11T14:10:48.434"
 
 julia> idata_cat3.observed_data
-╭────────────────────╮
-│ 10-element Dataset │
+┌ 10-element Dataset ┐
 ├────────────── dims ┤
   ↓ y_dim_1
 ├────────────────────┴─────────────── layers ┐


### PR DESCRIPTION
Currently doctests are failing due to changes in how `DimensionalData.AbstractDimStack` is rendered and due to the latest release of ArviZExampleData updating the MCMC draws for some examples we use. This PR updates the doctests accordingly.