### PR TITLE
Explicitly overload NamedTuple constructor method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.9"
+version = "0.4.10"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/convert_inference_data.jl
+++ b/src/convert_inference_data.jl
@@ -8,7 +8,7 @@ Convert `obj` to an [`InferenceData`](@ref).
 Base.convert(::Type{InferenceData}, obj) = convert_to_inference_data(obj)
 Base.convert(::Type{InferenceData}, obj::InferenceData) = obj
 Base.convert(::Type{NamedTuple}, data::InferenceData) = NamedTuple(data)
-NamedTuple(data::InferenceData) = parent(data)
+Base.NamedTuple(data::InferenceData) = parent(data)
 
 """
     convert_to_inference_data(obj; group, kwargs...) -> InferenceData


### PR DESCRIPTION
A conversion method from `InferenceData` to `NamedTuple` mistakenly was not imported or explicitly called from Base. It still worked but likely won't in future Julia versions, so this PR explicitly overloads `Base.NamedTuple`.