### PR TITLE
Use ANSI colors in HTML show method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferenceObjects"
 uuid = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.10"
+version = "0.4.11"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
 version = "0.4.10"
 
 [deps]
+ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -21,6 +22,7 @@ InferenceObjectsNCDatasetsExt = "NCDatasets"
 InferenceObjectsPosteriorStatsExt = ["PosteriorStats", "StatsBase"]
 
 [compat]
+ANSIColoredPrinters = "0.0.1"
 ArviZExampleData = "0.1.10"
 Dates = "1.9"
 DimensionalData = "0.27, 0.28, 0.29"

--- a/src/InferenceObjects.jl
+++ b/src/InferenceObjects.jl
@@ -1,5 +1,6 @@
 module InferenceObjects
 
+using ANSIColoredPrinters: ANSIColoredPrinters
 using Dates: Dates
 using DimensionalData: DimensionalData, Dimensions, LookupArrays
 using Random: Random

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -193,13 +193,20 @@ function Base.show(io::IO, ::MIME"text/plain", data::InferenceData)
 end
 function Base.show(io::IO, mime::MIME"text/html", data::InferenceData)
     show(io, mime, HTML("<div>InferenceData"))
+    io_ansicolor = IOBuffer()
+    ctx = IOContext(io_ansicolor, :compact => true, :color => true)
     for (name, group) in pairs(groups(data))
+        show(ctx, MIME"text/plain"(), group)
+        printer = ANSIColoredPrinters.HTMLPrinter(io_ansicolor)
         show(io, mime, HTML("""
         <details>
         <summary>$name</summary>
-        <pre><code>$(sprint(show, "text/plain", group))</code></pre>
+        """))
+        show(io, mime, printer)
+        show(io, mime, HTML("""
         </details>
         """))
+        take!(io_ansicolor)  # reset the buffer
     end
     return show(io, mime, HTML("</div>"))
 end


### PR DESCRIPTION
Currently when we show an HTML representation of `InferenceData`, we convert each `Dataset` to a plain-text string and embed it within a code block. This is convenient but doesn't look as good as when Documenter renders a dataset that's the output of an example block, because it shows the ASCI coloring that DimensionalData uses to associated dimensions with their coordinates and sizes.

This PR uses the same approach as Documenter, ANSIColoredPrinters, to convert a plain-text rendering of `Dataset` that includes ANSI coloring to a corresponding HTML representation.