### PR TITLE
Update docstrings for changes in DimensionalData show methods

### DIFF
--- a/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
+++ b/ext/InferenceObjectsPosteriorStatsExt/loo_pit.jl
@@ -27,9 +27,9 @@ julia> loo_result = loo(idata; var_name=:obs);
 
 julia> loo_pit(idata, loo_result.psis_result.log_weights; y_name=:obs)
 ┌ 8-element DimArray{Float64, 1} loo_pit_obs ┐
-├────────────────────────────────────────────┴─────────────────────────── dims ┐
-  ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
-└──────────────────────────────────────────────────────────────────────────────┘
+├────────────────────────────────────────────┴─────────────────── dims ┐
+  ↓ school Categorical{String} ["Choate", …, "Mt. Hermon"] Unordered
+└──────────────────────────────────────────────────────────────────────┘
  "Choate"            0.942759
  "Deerfield"         0.641057
  "Phillips Andover"  0.32729
@@ -86,9 +86,9 @@ julia> idata = load_example_data("centered_eight");
 
 julia> loo_pit(idata; y_name=:obs)
 ┌ 8-element DimArray{Float64, 1} loo_pit_obs ┐
-├────────────────────────────────────────────┴─────────────────────────── dims ┐
-  ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
-└──────────────────────────────────────────────────────────────────────────────┘
+├────────────────────────────────────────────┴─────────────────── dims ┐
+  ↓ school Categorical{String} ["Choate", …, "Mt. Hermon"] Unordered
+└──────────────────────────────────────────────────────────────────────┘
  "Choate"            0.942759
  "Deerfield"         0.641057
  "Phillips Andover"  0.32729

--- a/src/inference_data.jl
+++ b/src/inference_data.jl
@@ -311,15 +311,15 @@ InferenceData with groups:
 julia> idata_cat1.posterior
 ┌ 100×8×3 Dataset ┐
 ├─────────────────┴──────────────────────────────────── dims ┐
-  ↓ draw ,
+  ↓ draw,
   → chain,
-  ↗ a_dim Categorical{String} ["x", "y", "z"] ForwardOrdered
+  ↗ a_dim Categorical{String} ["x", …, "z"] ForwardOrdered
 ├──────────────────────────────────────────────────── layers ┤
   :a eltype: Float64 dims: draw, chain, a_dim size: 100×8×3
   :b eltype: Float64 dims: draw, chain size: 100×8
 ├────────────────────────────────────────────────── metadata ┤
   Dict{String, Any} with 1 entry:
-  "created_at" => "2025-02-04T10:49:16.704"
+  "created_at" => "2025-07-25T10:11:18.92"
 ```
 
 Alternatively, we can concatenate along a new `run` dimension, which will be created.
@@ -331,17 +331,17 @@ InferenceData with groups:
 
 julia> idata_cat2.posterior
 ┌ 100×4×3×2 Dataset ┐
-├───────────────────┴─────────────────────────────────── dims ┐
-  ↓ draw ,
+├───────────────────┴───────────────────────────────────────── dims ┐
+  ↓ draw,
   → chain,
-  ↗ a_dim Categorical{String} ["x", "y", "z"] ForwardOrdered,
+  ↗ a_dim Categorical{String} ["x", …, "z"] ForwardOrdered,
   ⬔ run
-├─────────────────────────────────────────────────────────────┴ layers ┐
+├─────────────────────────────────────────────────────────── layers ┤
   :a eltype: Float64 dims: draw, chain, a_dim, run size: 100×4×3×2
   :b eltype: Float64 dims: draw, chain, run size: 100×4×2
-├──────────────────────────────────────────────────────────── metadata ┤
+├───────────────────────────────────────────────────────── metadata ┤
   Dict{String, Any} with 1 entry:
-  "created_at" => "2025-02-04T10:49:16.704"
+  "created_at" => "2025-07-25T10:11:18.92"
 ```
 
 We can also concatenate only a subset of groups and merge the rest, which is useful when
@@ -363,27 +363,27 @@ InferenceData with groups:
 
 julia> idata_cat3.posterior
 ┌ 100×4×3×2 Dataset ┐
-├───────────────────┴─────────────────────────────────── dims ┐
-  ↓ draw ,
+├───────────────────┴───────────────────────────────────────── dims ┐
+  ↓ draw,
   → chain,
-  ↗ a_dim Categorical{String} ["x", "y", "z"] ForwardOrdered,
+  ↗ a_dim Categorical{String} ["x", …, "z"] ForwardOrdered,
   ⬔ run
-├─────────────────────────────────────────────────────────────┴ layers ┐
+├─────────────────────────────────────────────────────────── layers ┤
   :a eltype: Float64 dims: draw, chain, a_dim, run size: 100×4×3×2
   :b eltype: Float64 dims: draw, chain, run size: 100×4×2
-├──────────────────────────────────────────────────────────── metadata ┤
+├───────────────────────────────────────────────────────── metadata ┤
   Dict{String, Any} with 1 entry:
-  "created_at" => "2025-02-04T10:49:16.704"
+  "created_at" => "2025-07-25T10:11:18.92"
 
 julia> idata_cat3.observed_data
 ┌ 10-element Dataset ┐
-├────────────── dims ┤
+├────────────────────┴───────────────── dims ┐
   ↓ y_dim_1
-├────────────────────┴─────────────── layers ┐
+├──────────────────────────────────── layers ┤
   :y eltype: Float64 dims: y_dim_1 size: 10
 ├────────────────────────────────────────────┴ metadata ┐
   Dict{String, Any} with 1 entry:
-  "created_at" => "2025-02-04T10:49:16.71"
+  "created_at" => "2025-07-25T10:11:18.951"
 ```
 """
 function Base.cat(data::InferenceData, others::InferenceData...; groups=keys(data), dims)


### PR DESCRIPTION
https://github.com/rafaqz/DimensionalData.jl/pull/1002 made some improvements to the `show` methods in DimensionalData, which now cause our doctests to fail. This PR just updates the docstrings using the new `show` methods.