### PR TITLE
ci: drop x64 arch pin from CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.downgrade && 'Downgrade / ' || '' }}Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: ${{ matrix.downgrade && 'Downgrade / ' || '' }}Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -28,21 +28,16 @@ jobs:
           - 'pre'
         os:
           - ubuntu-latest
-        arch:
-          - x64
         downgrade: [false]
         include:
           - version: '1'
             os: windows-latest
-            arch: x64
             downgrade: false
           - version: '1'
             os: macOS-latest
-            arch: x64
             downgrade: false
           - version: 'min'
             os: ubuntu-latest
-            arch: x64
             downgrade: true
     steps:
       - uses: actions/checkout@v6
@@ -50,7 +45,6 @@ jobs:
         id: setup-julia
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-downgrade-compat@v2
         with:


### PR DESCRIPTION
Same bug shape as arviz-devs/ArviZExampleData.jl#52: macos-latest now resolves to an arm64-only image, and our matrix pins `arch: x64` for the macOS-latest job. This repo hasn't hit the failure yet, but it's the same latent bug. arch never actually varied across this matrix, so this drops it entirely and lets setup-julia pick the right architecture per runner.